### PR TITLE
feat: add `types` module

### DIFF
--- a/src/chains/arbitrum/index.ts
+++ b/src/chains/arbitrum/index.ts
@@ -1,7 +1,7 @@
 import { arbitrum as arbitrumMetadata } from '@wagmi/chains';
 import { Chain } from '@/chains';
-import { precompiles } from './vm/precompiles';
 import { opcodes } from './vm/opcodes';
+import { precompiles } from './vm/precompiles';
 
 export const arbitrum: Chain = {
   metadata: arbitrumMetadata,

--- a/src/chains/arbitrum/index.ts
+++ b/src/chains/arbitrum/index.ts
@@ -1,5 +1,5 @@
 import { arbitrum as arbitrumMetadata } from '@wagmi/chains';
-import { Chain } from '@/chains';
+import { Chain } from '@/types/chain';
 import { opcodes } from './vm/opcodes';
 import { precompiles } from './vm/precompiles';
 

--- a/src/chains/arbitrum/index.ts
+++ b/src/chains/arbitrum/index.ts
@@ -1,8 +1,10 @@
 import { arbitrum as arbitrumMetadata } from '@wagmi/chains';
 import { Chain } from '@/chains';
 import { precompiles } from './vm/precompiles';
+import { opcodes } from './vm/opcodes';
 
 export const arbitrum: Chain = {
   metadata: arbitrumMetadata,
   precompiles,
+  opcodes,
 };

--- a/src/chains/arbitrum/vm/opcodes/block/index.ts
+++ b/src/chains/arbitrum/vm/opcodes/block/index.ts
@@ -1,0 +1,13 @@
+import { Opcode } from "@/chains/types";
+import { number } from "./number";
+import { blockhash } from "@/chains/mainnet/vm/opcodes/block/blockhash";
+
+const modifiedOpcodes: Opcode[] = [
+  number,
+]
+
+const mainnetOpcodes: Opcode[] = [
+  blockhash,
+];
+
+export const opcodes: Opcode[] = [...modifiedOpcodes, ...mainnetOpcodes];

--- a/src/chains/arbitrum/vm/opcodes/block/index.ts
+++ b/src/chains/arbitrum/vm/opcodes/block/index.ts
@@ -1,13 +1,9 @@
-import { Opcode } from "@/chains/types";
-import { number } from "./number";
-import { blockhash } from "@/chains/mainnet/vm/opcodes/block/blockhash";
+import { blockhash } from '@/chains/mainnet/vm/opcodes/block/blockhash';
+import { Opcode } from '@/chains/types';
+import { number } from './number';
 
-const modifiedOpcodes: Opcode[] = [
-  number,
-]
+const modifiedOpcodes: Opcode[] = [number];
 
-const mainnetOpcodes: Opcode[] = [
-  blockhash,
-];
+const mainnetOpcodes: Opcode[] = [blockhash];
 
 export const opcodes: Opcode[] = [...modifiedOpcodes, ...mainnetOpcodes];

--- a/src/chains/arbitrum/vm/opcodes/block/index.ts
+++ b/src/chains/arbitrum/vm/opcodes/block/index.ts
@@ -1,5 +1,5 @@
 import { blockhash } from '@/chains/mainnet/vm/opcodes/block/blockhash';
-import { Opcode } from '@/chains/types';
+import { Opcode } from '@/types/opcode';
 import { number } from './number';
 
 const modifiedOpcodes: Opcode[] = [number];

--- a/src/chains/arbitrum/vm/opcodes/block/number.ts
+++ b/src/chains/arbitrum/vm/opcodes/block/number.ts
@@ -1,4 +1,4 @@
-import { Opcode } from '@/chains/types';
+import { Opcode } from '@/types/opcode';
 
 export const number: Opcode = {
   number: 43,

--- a/src/chains/arbitrum/vm/opcodes/block/number.ts
+++ b/src/chains/arbitrum/vm/opcodes/block/number.ts
@@ -1,0 +1,31 @@
+import { Opcode } from "@/chains/types";
+
+export const number: Opcode = {
+  number: 43,
+  name: 'number',
+  description: 'L2 block number',
+  minGas: 2,
+  inputs: [],
+  outputs: [
+    {
+      name: 'blockNumber',
+      description: 'The current L2 block number',
+    },
+  ],
+  examples: [
+    {
+      input: [],
+      output: '1636704767',
+    },
+  ],
+  errorCases: [
+    'Not enough gas.',
+    'Stack overflow.',
+  ],
+  notes: [],
+  references: [
+    'https://www.evm.codes/#43?fork=shanghai',
+    'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/instructions/block.py#L126',
+    'https://community.optimism.io/docs/developers/build/differences/#opcode-differences',
+  ],
+}

--- a/src/chains/arbitrum/vm/opcodes/block/number.ts
+++ b/src/chains/arbitrum/vm/opcodes/block/number.ts
@@ -1,4 +1,4 @@
-import { Opcode } from "@/chains/types";
+import { Opcode } from '@/chains/types';
 
 export const number: Opcode = {
   number: 43,
@@ -18,14 +18,11 @@ export const number: Opcode = {
       output: '1636704767',
     },
   ],
-  errorCases: [
-    'Not enough gas.',
-    'Stack overflow.',
-  ],
+  errorCases: ['Not enough gas.', 'Stack overflow.'],
   notes: [],
   references: [
     'https://www.evm.codes/#43?fork=shanghai',
     'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/instructions/block.py#L126',
     'https://community.optimism.io/docs/developers/build/differences/#opcode-differences',
   ],
-}
+};

--- a/src/chains/arbitrum/vm/opcodes/index.ts
+++ b/src/chains/arbitrum/vm/opcodes/index.ts
@@ -1,6 +1,6 @@
 import { opcodes as mainnetArithmeticOpcodes } from '@/chains/mainnet/vm/opcodes/arithmetic';
 import { opcodes as mainnetMemoryOpcodes } from '@/chains/mainnet/vm/opcodes/memory';
-import { Opcode } from '@/chains/types';
+import { Opcode } from '@/types/opcode';
 import { opcodes as blockOpcodes } from './block';
 
 const modifiedOpcodes: Opcode[] = [...blockOpcodes];

--- a/src/chains/arbitrum/vm/opcodes/index.ts
+++ b/src/chains/arbitrum/vm/opcodes/index.ts
@@ -1,15 +1,10 @@
-import { Opcode } from "@/chains/types";
-import { opcodes as mainnetArithmeticOpcodes } from "@/chains/mainnet/vm/opcodes/arithmetic";
-import { opcodes as blockOpcodes } from "./block";
-import { opcodes as mainnetMemoryOpcodes } from "@/chains/mainnet/vm/opcodes/memory";
+import { opcodes as mainnetArithmeticOpcodes } from '@/chains/mainnet/vm/opcodes/arithmetic';
+import { opcodes as mainnetMemoryOpcodes } from '@/chains/mainnet/vm/opcodes/memory';
+import { Opcode } from '@/chains/types';
+import { opcodes as blockOpcodes } from './block';
 
-const modifiedOpcodes: Opcode[] = [
-  ...blockOpcodes,
-]
+const modifiedOpcodes: Opcode[] = [...blockOpcodes];
 
-const mainnetOpcodes: Opcode[] = [
-  ...mainnetArithmeticOpcodes,
-  ...mainnetMemoryOpcodes,
-];
+const mainnetOpcodes: Opcode[] = [...mainnetArithmeticOpcodes, ...mainnetMemoryOpcodes];
 
 export const opcodes: Opcode[] = [...modifiedOpcodes, ...mainnetOpcodes];

--- a/src/chains/arbitrum/vm/opcodes/index.ts
+++ b/src/chains/arbitrum/vm/opcodes/index.ts
@@ -1,0 +1,15 @@
+import { Opcode } from "@/chains/types";
+import { opcodes as mainnetArithmeticOpcodes } from "@/chains/mainnet/vm/opcodes/arithmetic";
+import { opcodes as blockOpcodes } from "./block";
+import { opcodes as mainnetMemoryOpcodes } from "@/chains/mainnet/vm/opcodes/memory";
+
+const modifiedOpcodes: Opcode[] = [
+  ...blockOpcodes,
+]
+
+const mainnetOpcodes: Opcode[] = [
+  ...mainnetArithmeticOpcodes,
+  ...mainnetMemoryOpcodes,
+];
+
+export const opcodes: Opcode[] = [...modifiedOpcodes, ...mainnetOpcodes];

--- a/src/chains/arbitrum/vm/precompiles.ts
+++ b/src/chains/arbitrum/vm/precompiles.ts
@@ -1,5 +1,5 @@
-import { Precompile, Predeploy } from '@/chains';
 import { precompiles as mainnetPrecompiles } from '@/chains/mainnet/vm/precompiles';
+import { Precompile, Predeploy } from '@/types/precompiles';
 
 // https://developer.arbitrum.io/useful-addresses#arbitrum-precompiles-l2-same-on-all-arb-chains
 export const precompiles: (Precompile | Predeploy)[] = [

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -2,5 +2,4 @@ import { arbitrum } from '@/chains/arbitrum';
 import { mainnet } from '@/chains/mainnet';
 import { optimism } from '@/chains/optimism';
 
-export type { Chain, Precompile, Predeploy } from '@/chains/types';
 export const chains = { arbitrum, mainnet, optimism };

--- a/src/chains/mainnet/index.ts
+++ b/src/chains/mainnet/index.ts
@@ -1,7 +1,7 @@
 import { mainnet as mainnetMetadata } from '@wagmi/chains';
 import { Chain } from '@/chains';
-import { precompiles } from './vm/precompiles';
 import { opcodes } from './vm/opcodes';
+import { precompiles } from './vm/precompiles';
 
 export const mainnet: Chain = {
   metadata: mainnetMetadata,

--- a/src/chains/mainnet/index.ts
+++ b/src/chains/mainnet/index.ts
@@ -1,8 +1,10 @@
 import { mainnet as mainnetMetadata } from '@wagmi/chains';
 import { Chain } from '@/chains';
 import { precompiles } from './vm/precompiles';
+import { opcodes } from './vm/opcodes';
 
 export const mainnet: Chain = {
   metadata: mainnetMetadata,
   precompiles,
+  opcodes,
 };

--- a/src/chains/mainnet/index.ts
+++ b/src/chains/mainnet/index.ts
@@ -1,5 +1,5 @@
 import { mainnet as mainnetMetadata } from '@wagmi/chains';
-import { Chain } from '@/chains';
+import { Chain } from '@/types/chain';
 import { opcodes } from './vm/opcodes';
 import { precompiles } from './vm/precompiles';
 

--- a/src/chains/mainnet/vm/opcodes/arithmetic/add.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/add.ts
@@ -1,4 +1,4 @@
-import { Opcode } from "@/chains/types";
+import { Opcode } from '@/chains/types';
 
 export const add: Opcode = {
   number: 1,
@@ -27,14 +27,12 @@ export const add: Opcode = {
       output: '30',
     },
   ],
-  playgroundLink: 'https://www.evm.codes/playground?unit=Wei&codeType=Mnemonic&code=%27y1z0z0twwy2v32%200xsssszt%27~uuuuzv1%201y%2F%2F%20Example%20w%5CnvwPUSHuFFtwADDs~~%01stuvwyz~_',
-  errorCases: [
-    'Not enough gas',
-    'Not enough values on the stack',
-  ],
+  playgroundLink:
+    'https://www.evm.codes/playground?unit=Wei&codeType=Mnemonic&code=%27y1z0z0twwy2v32%200xsssszt%27~uuuuzv1%201y%2F%2F%20Example%20w%5CnvwPUSHuFFtwADDs~~%01stuvwyz~_',
+  errorCases: ['Not enough gas', 'Not enough values on the stack'],
   notes: [],
   references: [
     'https://www.evm.codes/#01?fork=shanghai',
     'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/instructions/arithmetic.py#L30',
   ],
-}
+};

--- a/src/chains/mainnet/vm/opcodes/arithmetic/add.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/add.ts
@@ -1,4 +1,4 @@
-import { Opcode } from '@/chains/types';
+import { Opcode } from '@/types/opcode';
 
 export const add: Opcode = {
   number: 1,

--- a/src/chains/mainnet/vm/opcodes/arithmetic/add.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/add.ts
@@ -1,0 +1,40 @@
+import { Opcode } from "@/chains/types";
+
+export const add: Opcode = {
+  number: 1,
+  name: 'add',
+  description: 'Addition operation',
+  minGas: 3,
+  inputs: [
+    {
+      name: 'a',
+      description: 'The first integer value to add',
+    },
+    {
+      name: 'b',
+      description: 'The second integer value to add',
+    },
+  ],
+  outputs: [
+    {
+      name: 'a + b',
+      description: 'The integer result of the addition modulo 2**256',
+    },
+  ],
+  examples: [
+    {
+      input: ['10', '20'],
+      output: '30',
+    },
+  ],
+  playgroundLink: 'https://www.evm.codes/playground?unit=Wei&codeType=Mnemonic&code=%27y1z0z0twwy2v32%200xsssszt%27~uuuuzv1%201y%2F%2F%20Example%20w%5CnvwPUSHuFFtwADDs~~%01stuvwyz~_',
+  errorCases: [
+    'Not enough gas',
+    'Not enough values on the stack',
+  ],
+  notes: [],
+  references: [
+    'https://www.evm.codes/#01?fork=shanghai',
+    'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/instructions/arithmetic.py#L30',
+  ],
+}

--- a/src/chains/mainnet/vm/opcodes/arithmetic/index.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/index.ts
@@ -1,0 +1,6 @@
+import { Opcode } from "@/chains/types";
+import { add } from "./add";
+
+export const opcodes: Opcode[] = [
+  add,
+];

--- a/src/chains/mainnet/vm/opcodes/arithmetic/index.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/index.ts
@@ -1,4 +1,4 @@
-import { Opcode } from '@/chains/types';
+import { Opcode } from '@/types/opcode';
 import { add } from './add';
 
 export const opcodes: Opcode[] = [add];

--- a/src/chains/mainnet/vm/opcodes/arithmetic/index.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/index.ts
@@ -1,6 +1,4 @@
-import { Opcode } from "@/chains/types";
-import { add } from "./add";
+import { Opcode } from '@/chains/types';
+import { add } from './add';
 
-export const opcodes: Opcode[] = [
-  add,
-];
+export const opcodes: Opcode[] = [add];

--- a/src/chains/mainnet/vm/opcodes/block/blockhash.ts
+++ b/src/chains/mainnet/vm/opcodes/block/blockhash.ts
@@ -1,0 +1,35 @@
+import { Opcode } from "@/chains/types";
+
+export const blockhash: Opcode = {
+  number: 40,
+  name: 'blockhash',
+  description: 'Get the hash of one of the 256 most recent complete blocks',
+  minGas: 20,
+  inputs: [
+    {
+      name: 'blockNumber',
+      description: 'The block number to get the hash from. Valid range is the last 256 blocks (not including the current one). Current block number can be queried with NUMBER.',
+    },
+  ],
+  outputs: [
+    {
+      name: 'hash',
+      description: 'The hash of the chosen block, or 0 if the block number is not in the valid range',
+    },
+  ],
+  examples: [
+    {
+      input: '599423545',
+      output: '0x29045A592007D0C246EF02C2223570DA9522D0CF0F73282C79A1BC8F0BB2C238',
+    },
+  ],
+  errorCases: [
+    'Not enough gas',
+    'Not enough values on the stack',
+  ],
+  notes: [],
+  references: [
+    'https://www.evm.codes/#40?fork=shanghai',
+    'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/instructions/block.py#L22',
+  ],
+}

--- a/src/chains/mainnet/vm/opcodes/block/blockhash.ts
+++ b/src/chains/mainnet/vm/opcodes/block/blockhash.ts
@@ -1,4 +1,4 @@
-import { Opcode } from '@/chains/types';
+import { Opcode } from '@/types/opcode';
 
 export const blockhash: Opcode = {
   number: 40,

--- a/src/chains/mainnet/vm/opcodes/block/blockhash.ts
+++ b/src/chains/mainnet/vm/opcodes/block/blockhash.ts
@@ -1,4 +1,4 @@
-import { Opcode } from "@/chains/types";
+import { Opcode } from '@/chains/types';
 
 export const blockhash: Opcode = {
   number: 40,
@@ -8,13 +8,15 @@ export const blockhash: Opcode = {
   inputs: [
     {
       name: 'blockNumber',
-      description: 'The block number to get the hash from. Valid range is the last 256 blocks (not including the current one). Current block number can be queried with NUMBER.',
+      description:
+        'The block number to get the hash from. Valid range is the last 256 blocks (not including the current one). Current block number can be queried with NUMBER.',
     },
   ],
   outputs: [
     {
       name: 'hash',
-      description: 'The hash of the chosen block, or 0 if the block number is not in the valid range',
+      description:
+        'The hash of the chosen block, or 0 if the block number is not in the valid range',
     },
   ],
   examples: [
@@ -23,13 +25,10 @@ export const blockhash: Opcode = {
       output: '0x29045A592007D0C246EF02C2223570DA9522D0CF0F73282C79A1BC8F0BB2C238',
     },
   ],
-  errorCases: [
-    'Not enough gas',
-    'Not enough values on the stack',
-  ],
+  errorCases: ['Not enough gas', 'Not enough values on the stack'],
   notes: [],
   references: [
     'https://www.evm.codes/#40?fork=shanghai',
     'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/instructions/block.py#L22',
   ],
-}
+};

--- a/src/chains/mainnet/vm/opcodes/block/index.ts
+++ b/src/chains/mainnet/vm/opcodes/block/index.ts
@@ -1,4 +1,4 @@
-import { Opcode } from '@/chains/types';
+import { Opcode } from '@/types/opcode';
 import { blockhash } from './blockhash';
 import { number } from './number';
 

--- a/src/chains/mainnet/vm/opcodes/block/index.ts
+++ b/src/chains/mainnet/vm/opcodes/block/index.ts
@@ -1,0 +1,8 @@
+import { Opcode } from "@/chains/types";
+import { number } from "./number";
+import { blockhash } from "./blockhash";
+
+export const opcodes: Opcode[] = [
+  blockhash,
+  number,
+];

--- a/src/chains/mainnet/vm/opcodes/block/index.ts
+++ b/src/chains/mainnet/vm/opcodes/block/index.ts
@@ -1,8 +1,5 @@
-import { Opcode } from "@/chains/types";
-import { number } from "./number";
-import { blockhash } from "./blockhash";
+import { Opcode } from '@/chains/types';
+import { blockhash } from './blockhash';
+import { number } from './number';
 
-export const opcodes: Opcode[] = [
-  blockhash,
-  number,
-];
+export const opcodes: Opcode[] = [blockhash, number];

--- a/src/chains/mainnet/vm/opcodes/block/number.ts
+++ b/src/chains/mainnet/vm/opcodes/block/number.ts
@@ -1,4 +1,4 @@
-import { Opcode } from '@/chains/types';
+import { Opcode } from '@/types/opcode';
 
 export const number: Opcode = {
   number: 43,

--- a/src/chains/mainnet/vm/opcodes/block/number.ts
+++ b/src/chains/mainnet/vm/opcodes/block/number.ts
@@ -1,9 +1,9 @@
-import { Opcode } from "@/chains/types";
+import { Opcode } from '@/chains/types';
 
 export const number: Opcode = {
   number: 43,
   name: 'number',
-  description: 'Get the block\'s number',
+  description: "Get the block's number",
   minGas: 2,
   inputs: [],
   outputs: [
@@ -18,13 +18,10 @@ export const number: Opcode = {
       output: '1636704767',
     },
   ],
-  errorCases: [
-    'Not enough gas',
-    'Stack overflow',
-  ],
+  errorCases: ['Not enough gas', 'Stack overflow'],
   notes: [],
   references: [
     'https://www.evm.codes/#43?fork=shanghai',
     'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/instructions/block.py#L126',
   ],
-}
+};

--- a/src/chains/mainnet/vm/opcodes/block/number.ts
+++ b/src/chains/mainnet/vm/opcodes/block/number.ts
@@ -1,0 +1,30 @@
+import { Opcode } from "@/chains/types";
+
+export const number: Opcode = {
+  number: 43,
+  name: 'number',
+  description: 'Get the block\'s number',
+  minGas: 2,
+  inputs: [],
+  outputs: [
+    {
+      name: 'blockNumber',
+      description: 'The current block number',
+    },
+  ],
+  examples: [
+    {
+      input: [],
+      output: '1636704767',
+    },
+  ],
+  errorCases: [
+    'Not enough gas',
+    'Stack overflow',
+  ],
+  notes: [],
+  references: [
+    'https://www.evm.codes/#43?fork=shanghai',
+    'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/instructions/block.py#L126',
+  ],
+}

--- a/src/chains/mainnet/vm/opcodes/index.ts
+++ b/src/chains/mainnet/vm/opcodes/index.ts
@@ -1,10 +1,6 @@
-import { Opcode } from "@/chains/types";
-import { opcodes as arithmeticOpcodes } from "./arithmetic";
-import { opcodes as blockOpcodes } from "./block";
-import { opcodes as memoryOpcodes } from "./memory";
+import { Opcode } from '@/chains/types';
+import { opcodes as arithmeticOpcodes } from './arithmetic';
+import { opcodes as blockOpcodes } from './block';
+import { opcodes as memoryOpcodes } from './memory';
 
-export const opcodes: Opcode[] = [
-  ...arithmeticOpcodes,
-  ...blockOpcodes,
-  ...memoryOpcodes,
-];
+export const opcodes: Opcode[] = [...arithmeticOpcodes, ...blockOpcodes, ...memoryOpcodes];

--- a/src/chains/mainnet/vm/opcodes/index.ts
+++ b/src/chains/mainnet/vm/opcodes/index.ts
@@ -1,4 +1,4 @@
-import { Opcode } from '@/chains/types';
+import { Opcode } from '@/types/opcode';
 import { opcodes as arithmeticOpcodes } from './arithmetic';
 import { opcodes as blockOpcodes } from './block';
 import { opcodes as memoryOpcodes } from './memory';

--- a/src/chains/mainnet/vm/opcodes/index.ts
+++ b/src/chains/mainnet/vm/opcodes/index.ts
@@ -1,0 +1,10 @@
+import { Opcode } from "@/chains/types";
+import { opcodes as arithmeticOpcodes } from "./arithmetic";
+import { opcodes as blockOpcodes } from "./block";
+import { opcodes as memoryOpcodes } from "./memory";
+
+export const opcodes: Opcode[] = [
+  ...arithmeticOpcodes,
+  ...blockOpcodes,
+  ...memoryOpcodes,
+];

--- a/src/chains/mainnet/vm/opcodes/memory/index.ts
+++ b/src/chains/mainnet/vm/opcodes/memory/index.ts
@@ -1,0 +1,6 @@
+import { Opcode } from "@/chains/types";
+import { mstore } from "./mstore";
+
+export const opcodes: Opcode[] = [
+  mstore,
+];

--- a/src/chains/mainnet/vm/opcodes/memory/index.ts
+++ b/src/chains/mainnet/vm/opcodes/memory/index.ts
@@ -1,4 +1,4 @@
-import { Opcode } from '@/chains/types';
+import { Opcode } from '@/types/opcode';
 import { mstore } from './mstore';
 
 export const opcodes: Opcode[] = [mstore];

--- a/src/chains/mainnet/vm/opcodes/memory/index.ts
+++ b/src/chains/mainnet/vm/opcodes/memory/index.ts
@@ -1,6 +1,4 @@
-import { Opcode } from "@/chains/types";
-import { mstore } from "./mstore";
+import { Opcode } from '@/chains/types';
+import { mstore } from './mstore';
 
-export const opcodes: Opcode[] = [
-  mstore,
-];
+export const opcodes: Opcode[] = [mstore];

--- a/src/chains/mainnet/vm/opcodes/memory/mstore.ts
+++ b/src/chains/mainnet/vm/opcodes/memory/mstore.ts
@@ -1,0 +1,67 @@
+import { Opcode } from "@/chains/types";
+
+export const mstore: Opcode = {
+  number: 52,
+  name: 'mstore',
+  description: 'Save word to memory',
+  minGas: 3,
+  gasComputation: {
+    name: 'Memory expansion',
+    description: 'During a smart contract execution, memory can be accessed with opcodes. When an offset is first accessed (either read or write), memory may trigger an expansion, which costs gas. Memory expansion may be triggered when the byte offset (modulo 32) accessed is bigger than previous offsets. If a larger offset trigger of memory expansion occurs, the cost of accessing the higher offset is computed and removed from the total gas available at the current call context. Thus, only the additional bytes of memory must be paid for.',
+    expression: 'memory_expansion_cost = new_memory_cost - last_memory_cost',
+    variables: [
+      {
+        name: 'memory_cost',
+        description: 'The memory cost function for a given machine state',
+        expression: '(memory_size_word ** 2) / 512 + (3 * memory_size_word)',
+      },
+      {
+        name: 'memory_size_word',
+        description: 'Number of (32-byte) words required for memory after the operation in question',
+        expression: '(memory_byte_size + 31) / 32',
+      },
+      {
+        name: 'memory_byte_size',
+        description: 'The highest referenced memory address after the operation in question (in bytes)',
+      }
+    ],
+  },
+  inputs: [
+    {
+      name: 'offset',
+      description: 'offset in the memory in bytes',
+    },
+    {
+      name: 'value',
+      description: '32-bytes value to write in the memory',
+    },
+  ],
+  outputs: [],
+  examples: [
+    {
+      input: ['0', '0xFF'],
+      memory: {
+        before: '0',
+        after: '0x00000000000000000000000000000000000000000000000000000000000000FF',
+      },
+    },
+    {
+      input: ['1', '0xFF'],
+      memory: {
+        before: '0',
+        after: '0x0000000000000000000000000000000000000000000000000000000000000000FF',
+      },
+    },
+  ],
+  playgroundLink: 'https://www.evm.codes/playground?unit=Wei&codeType=Mnemonic&code=%27z1v0wyz2v1w%27~yPUSH1%20z%2F%2F%20Example%20y%5CnwyMSTOREyv~0xFF~%01vwyz~_',
+  errorCases: [
+    'Not enough gas',
+    'Not enough values on the stack',
+  ],
+  notes: [],
+  references: [
+    'https://www.evm.codes/#52?fork=shanghai',
+    'https://www.evm.codes/about#memoryexpansion',
+    'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/instructions/memory.py#L27',
+  ],
+}

--- a/src/chains/mainnet/vm/opcodes/memory/mstore.ts
+++ b/src/chains/mainnet/vm/opcodes/memory/mstore.ts
@@ -1,4 +1,4 @@
-import { Opcode } from '@/chains/types';
+import { Opcode } from '@/types/opcode';
 
 export const mstore: Opcode = {
   number: 52,

--- a/src/chains/mainnet/vm/opcodes/memory/mstore.ts
+++ b/src/chains/mainnet/vm/opcodes/memory/mstore.ts
@@ -1,4 +1,4 @@
-import { Opcode } from "@/chains/types";
+import { Opcode } from '@/chains/types';
 
 export const mstore: Opcode = {
   number: 52,
@@ -7,7 +7,8 @@ export const mstore: Opcode = {
   minGas: 3,
   gasComputation: {
     name: 'Memory expansion',
-    description: 'During a smart contract execution, memory can be accessed with opcodes. When an offset is first accessed (either read or write), memory may trigger an expansion, which costs gas. Memory expansion may be triggered when the byte offset (modulo 32) accessed is bigger than previous offsets. If a larger offset trigger of memory expansion occurs, the cost of accessing the higher offset is computed and removed from the total gas available at the current call context. Thus, only the additional bytes of memory must be paid for.',
+    description:
+      'During a smart contract execution, memory can be accessed with opcodes. When an offset is first accessed (either read or write), memory may trigger an expansion, which costs gas. Memory expansion may be triggered when the byte offset (modulo 32) accessed is bigger than previous offsets. If a larger offset trigger of memory expansion occurs, the cost of accessing the higher offset is computed and removed from the total gas available at the current call context. Thus, only the additional bytes of memory must be paid for.',
     expression: 'memory_expansion_cost = new_memory_cost - last_memory_cost',
     variables: [
       {
@@ -17,13 +18,15 @@ export const mstore: Opcode = {
       },
       {
         name: 'memory_size_word',
-        description: 'Number of (32-byte) words required for memory after the operation in question',
+        description:
+          'Number of (32-byte) words required for memory after the operation in question',
         expression: '(memory_byte_size + 31) / 32',
       },
       {
         name: 'memory_byte_size',
-        description: 'The highest referenced memory address after the operation in question (in bytes)',
-      }
+        description:
+          'The highest referenced memory address after the operation in question (in bytes)',
+      },
     ],
   },
   inputs: [
@@ -53,15 +56,13 @@ export const mstore: Opcode = {
       },
     },
   ],
-  playgroundLink: 'https://www.evm.codes/playground?unit=Wei&codeType=Mnemonic&code=%27z1v0wyz2v1w%27~yPUSH1%20z%2F%2F%20Example%20y%5CnwyMSTOREyv~0xFF~%01vwyz~_',
-  errorCases: [
-    'Not enough gas',
-    'Not enough values on the stack',
-  ],
+  playgroundLink:
+    'https://www.evm.codes/playground?unit=Wei&codeType=Mnemonic&code=%27z1v0wyz2v1w%27~yPUSH1%20z%2F%2F%20Example%20y%5CnwyMSTOREyv~0xFF~%01vwyz~_',
+  errorCases: ['Not enough gas', 'Not enough values on the stack'],
   notes: [],
   references: [
     'https://www.evm.codes/#52?fork=shanghai',
     'https://www.evm.codes/about#memoryexpansion',
     'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/instructions/memory.py#L27',
   ],
-}
+};

--- a/src/chains/mainnet/vm/precompiles.ts
+++ b/src/chains/mainnet/vm/precompiles.ts
@@ -1,4 +1,4 @@
-import { Precompile } from '@/chains';
+import { Precompile } from '@/types/precompiles';
 
 // TODO the input and output fields are not used yet therefore not all of them are filled out.
 export const precompiles: Precompile[] = [

--- a/src/chains/optimism/index.ts
+++ b/src/chains/optimism/index.ts
@@ -1,5 +1,5 @@
 import { optimism as optimismMetadata } from '@wagmi/chains';
-import { Chain } from '@/chains';
+import { Chain } from '@/types/chain';
 import { opcodes } from './vm/opcodes';
 import { precompiles } from './vm/precompiles';
 

--- a/src/chains/optimism/index.ts
+++ b/src/chains/optimism/index.ts
@@ -1,8 +1,10 @@
 import { optimism as optimismMetadata } from '@wagmi/chains';
 import { Chain } from '@/chains';
 import { precompiles } from './vm/precompiles';
+import { opcodes } from './vm/opcodes';
 
 export const optimism: Chain = {
   metadata: optimismMetadata,
   precompiles,
+  opcodes,
 };

--- a/src/chains/optimism/index.ts
+++ b/src/chains/optimism/index.ts
@@ -1,7 +1,7 @@
 import { optimism as optimismMetadata } from '@wagmi/chains';
 import { Chain } from '@/chains';
-import { precompiles } from './vm/precompiles';
 import { opcodes } from './vm/opcodes';
+import { precompiles } from './vm/precompiles';
 
 export const optimism: Chain = {
   metadata: optimismMetadata,

--- a/src/chains/optimism/vm/opcodes/block/index.ts
+++ b/src/chains/optimism/vm/opcodes/block/index.ts
@@ -1,0 +1,13 @@
+import { Opcode } from "@/chains/types";
+import { number } from "./number";
+import { blockhash } from "@/chains/mainnet/vm/opcodes/block/blockhash";
+
+const modifiedOpcodes: Opcode[] = [
+  number,
+]
+
+const mainnetOpcodes: Opcode[] = [
+  blockhash,
+];
+
+export const opcodes: Opcode[] = [...modifiedOpcodes, ...mainnetOpcodes];

--- a/src/chains/optimism/vm/opcodes/block/index.ts
+++ b/src/chains/optimism/vm/opcodes/block/index.ts
@@ -1,13 +1,9 @@
-import { Opcode } from "@/chains/types";
-import { number } from "./number";
-import { blockhash } from "@/chains/mainnet/vm/opcodes/block/blockhash";
+import { blockhash } from '@/chains/mainnet/vm/opcodes/block/blockhash';
+import { Opcode } from '@/chains/types';
+import { number } from './number';
 
-const modifiedOpcodes: Opcode[] = [
-  number,
-]
+const modifiedOpcodes: Opcode[] = [number];
 
-const mainnetOpcodes: Opcode[] = [
-  blockhash,
-];
+const mainnetOpcodes: Opcode[] = [blockhash];
 
 export const opcodes: Opcode[] = [...modifiedOpcodes, ...mainnetOpcodes];

--- a/src/chains/optimism/vm/opcodes/block/index.ts
+++ b/src/chains/optimism/vm/opcodes/block/index.ts
@@ -1,5 +1,5 @@
 import { blockhash } from '@/chains/mainnet/vm/opcodes/block/blockhash';
-import { Opcode } from '@/chains/types';
+import { Opcode } from '@/types/opcode';
 import { number } from './number';
 
 const modifiedOpcodes: Opcode[] = [number];

--- a/src/chains/optimism/vm/opcodes/block/number.ts
+++ b/src/chains/optimism/vm/opcodes/block/number.ts
@@ -1,4 +1,4 @@
-import { Opcode } from '@/chains/types';
+import { Opcode } from '@/types/opcode';
 
 export const number: Opcode = {
   number: 43,

--- a/src/chains/optimism/vm/opcodes/block/number.ts
+++ b/src/chains/optimism/vm/opcodes/block/number.ts
@@ -1,0 +1,31 @@
+import { Opcode } from "@/chains/types";
+
+export const number: Opcode = {
+  number: 43,
+  name: 'number',
+  description: 'Get the L2 block\'s number',
+  minGas: 2,
+  inputs: [],
+  outputs: [
+    {
+      name: 'blockNumber',
+      description: 'The current L2 block number',
+    },
+  ],
+  examples: [
+    {
+      input: [],
+      output: '1636704767',
+    },
+  ],
+  errorCases: [
+    'Not enough gas',
+    'Stack overflow',
+  ],
+  notes: [],
+  references: [
+    'https://www.evm.codes/#43?fork=shanghai',
+    'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/instructions/block.py#L126',
+    'https://developer.arbitrum.io/time#arbitrum-block-numbers',
+  ],
+}

--- a/src/chains/optimism/vm/opcodes/block/number.ts
+++ b/src/chains/optimism/vm/opcodes/block/number.ts
@@ -1,9 +1,9 @@
-import { Opcode } from "@/chains/types";
+import { Opcode } from '@/chains/types';
 
 export const number: Opcode = {
   number: 43,
   name: 'number',
-  description: 'Get the L2 block\'s number',
+  description: "Get the L2 block's number",
   minGas: 2,
   inputs: [],
   outputs: [
@@ -18,14 +18,11 @@ export const number: Opcode = {
       output: '1636704767',
     },
   ],
-  errorCases: [
-    'Not enough gas',
-    'Stack overflow',
-  ],
+  errorCases: ['Not enough gas', 'Stack overflow'],
   notes: [],
   references: [
     'https://www.evm.codes/#43?fork=shanghai',
     'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/instructions/block.py#L126',
     'https://developer.arbitrum.io/time#arbitrum-block-numbers',
   ],
-}
+};

--- a/src/chains/optimism/vm/opcodes/index.ts
+++ b/src/chains/optimism/vm/opcodes/index.ts
@@ -1,6 +1,6 @@
 import { opcodes as mainnetArithmeticOpcodes } from '@/chains/mainnet/vm/opcodes/arithmetic';
 import { opcodes as mainnetMemoryOpcodes } from '@/chains/mainnet/vm/opcodes/memory';
-import { Opcode } from '@/chains/types';
+import { Opcode } from '@/types/opcode';
 import { opcodes as blockOpcodes } from './block';
 
 const modifiedOpcodes: Opcode[] = [...blockOpcodes];

--- a/src/chains/optimism/vm/opcodes/index.ts
+++ b/src/chains/optimism/vm/opcodes/index.ts
@@ -1,15 +1,10 @@
-import { Opcode } from "@/chains/types";
-import { opcodes as mainnetArithmeticOpcodes } from "@/chains/mainnet/vm/opcodes/arithmetic";
-import { opcodes as blockOpcodes } from "./block";
-import { opcodes as mainnetMemoryOpcodes } from "@/chains/mainnet/vm/opcodes/memory";
+import { opcodes as mainnetArithmeticOpcodes } from '@/chains/mainnet/vm/opcodes/arithmetic';
+import { opcodes as mainnetMemoryOpcodes } from '@/chains/mainnet/vm/opcodes/memory';
+import { Opcode } from '@/chains/types';
+import { opcodes as blockOpcodes } from './block';
 
-const modifiedOpcodes: Opcode[] = [
-  ...blockOpcodes,
-]
+const modifiedOpcodes: Opcode[] = [...blockOpcodes];
 
-const mainnetOpcodes: Opcode[] = [
-  ...mainnetArithmeticOpcodes,
-  ...mainnetMemoryOpcodes,
-];
+const mainnetOpcodes: Opcode[] = [...mainnetArithmeticOpcodes, ...mainnetMemoryOpcodes];
 
 export const opcodes: Opcode[] = [...modifiedOpcodes, ...mainnetOpcodes];

--- a/src/chains/optimism/vm/opcodes/index.ts
+++ b/src/chains/optimism/vm/opcodes/index.ts
@@ -1,0 +1,15 @@
+import { Opcode } from "@/chains/types";
+import { opcodes as mainnetArithmeticOpcodes } from "@/chains/mainnet/vm/opcodes/arithmetic";
+import { opcodes as blockOpcodes } from "./block";
+import { opcodes as mainnetMemoryOpcodes } from "@/chains/mainnet/vm/opcodes/memory";
+
+const modifiedOpcodes: Opcode[] = [
+  ...blockOpcodes,
+]
+
+const mainnetOpcodes: Opcode[] = [
+  ...mainnetArithmeticOpcodes,
+  ...mainnetMemoryOpcodes,
+];
+
+export const opcodes: Opcode[] = [...modifiedOpcodes, ...mainnetOpcodes];

--- a/src/chains/optimism/vm/precompiles.ts
+++ b/src/chains/optimism/vm/precompiles.ts
@@ -1,5 +1,5 @@
-import { Precompile, Predeploy } from '@/chains';
 import { precompiles as mainnetPrecompiles } from '@/chains/mainnet/vm/precompiles';
+import { Precompile, Predeploy } from '@/types/precompiles';
 
 // https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md
 export const precompiles: (Precompile | Predeploy)[] = [

--- a/src/chains/types.ts
+++ b/src/chains/types.ts
@@ -8,6 +8,30 @@ type PrecompileParam = {
   description: string;
 };
 
+type Variable = {
+  name: string;
+  description: string;
+  expression?: string;
+}
+
+type Computation = {
+  name: string;
+  description: string;
+  expression: string;
+  variables: Variable[];
+}
+
+type Memory = {
+  before: string;
+  after: string;
+}
+
+type Example = {
+  input: (string | string[]);
+  output?: string;
+  memory?: Memory;
+}
+
 export type Predeploy = {
   address: Address;
   name: string;
@@ -25,7 +49,23 @@ export type Precompile = {
   references: string[];
 };
 
+export type Opcode = {
+  number: number;
+  name: string;
+  description: string;
+  minGas: number;
+  gasComputation?: (number | Computation);
+  inputs: Variable[];
+  outputs: Variable[];
+  examples: Example[];
+  playgroundLink?: string;
+  errorCases: string[];
+  notes: string[];
+  references: string[];
+}
+
 export type Chain = {
   metadata: Metadata;
   precompiles: (Precompile | Predeploy)[];
+  opcodes: Opcode[];
 };

--- a/src/chains/types.ts
+++ b/src/chains/types.ts
@@ -14,7 +14,7 @@ type Variable = {
   expression?: string;
 }
 
-type Computation = {
+type GasComputation = {
   name: string;
   description: string;
   expression: string;
@@ -54,7 +54,7 @@ export type Opcode = {
   name: string;
   description: string;
   minGas: number;
-  gasComputation?: (number | Computation);
+  gasComputation?: GasComputation;
   inputs: Variable[];
   outputs: Variable[];
   examples: Example[];

--- a/src/chains/types.ts
+++ b/src/chains/types.ts
@@ -12,25 +12,25 @@ type Variable = {
   name: string;
   description: string;
   expression?: string;
-}
+};
 
 type GasComputation = {
   name: string;
   description: string;
   expression: string;
   variables: Variable[];
-}
+};
 
 type Memory = {
   before: string;
   after: string;
-}
+};
 
 type Example = {
-  input: (string | string[]);
+  input: string | string[];
   output?: string;
   memory?: Memory;
-}
+};
 
 export type Predeploy = {
   address: Address;
@@ -62,7 +62,7 @@ export type Opcode = {
   errorCases: string[];
   notes: string[];
   references: string[];
-}
+};
 
 export type Chain = {
   metadata: Metadata;

--- a/src/components/ChainDiffSelector.tsx
+++ b/src/components/ChainDiffSelector.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { useRouter } from 'next/router';
-import { Chain, chains } from '@/chains';
+import { chains } from '@/chains';
 import { ChainDiffSelectorChainCombobox } from '@/components/ui/ChainDiffSelectorChainCombobox';
+import { Chain } from '@/types/chain';
 
 export const ChainDiffSelector = () => {
   const router = useRouter();

--- a/src/components/diff/DiffPrecompiles.tsx
+++ b/src/components/diff/DiffPrecompiles.tsx
@@ -1,5 +1,5 @@
 import { Address, getAddress } from 'viem';
-import { Precompile, Predeploy } from '@/chains';
+import { Precompile, Predeploy } from '@/types/precompiles';
 
 type Props = {
   base: (Precompile | Predeploy)[];

--- a/src/components/ui/ChainDiffSelectorChainCombobox.tsx
+++ b/src/components/ui/ChainDiffSelectorChainCombobox.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { Combobox } from '@headlessui/react';
 import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid';
-import { Chain } from '@/chains/types';
 import { classNames } from '@/lib/utils';
+import { Chain } from '@/types/chain';
 
 interface Props {
   label: string;

--- a/src/pages/diff.tsx
+++ b/src/pages/diff.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import { useRouter } from 'next/router';
-import { Chain, chains } from '@/chains';
+import { chains } from '@/chains';
 import { ChainDiffSelector } from '@/components/ChainDiffSelector';
 import { DiffMetadata } from '@/components/diff/DiffMetadata';
 import { DiffPrecompiles } from '@/components/diff/DiffPrecompiles';
 import { Toggle } from '@/components/ui/Toggle';
+import { Chain } from '@/types/chain';
 
 const Diff = () => {
   // -------- Parse query parameters --------

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -1,0 +1,9 @@
+import { Chain as Metadata } from '@wagmi/chains';
+import { Opcode } from './opcode';
+import { Precompile, Predeploy } from './precompiles';
+
+export type Chain = {
+  metadata: Metadata;
+  precompiles: (Precompile | Predeploy)[];
+  opcodes: Opcode[];
+};

--- a/src/types/opcode.ts
+++ b/src/types/opcode.ts
@@ -1,13 +1,3 @@
-import { Chain as Metadata } from '@wagmi/chains';
-import { Address } from 'viem';
-
-type PrecompileParam = {
-  byteStart: number;
-  byteLength: number;
-  name: string;
-  description: string;
-};
-
 type Variable = {
   name: string;
   description: string;
@@ -32,23 +22,6 @@ type Example = {
   memory?: Memory;
 };
 
-export type Predeploy = {
-  address: Address;
-  name: string;
-  description: string;
-  deprecated: boolean;
-};
-
-export type Precompile = {
-  address: Address;
-  name: string;
-  description: string;
-  minGas: number;
-  input: PrecompileParam[];
-  output: PrecompileParam[];
-  references: string[];
-};
-
 export type Opcode = {
   number: number;
   name: string;
@@ -62,10 +35,4 @@ export type Opcode = {
   errorCases: string[];
   notes: string[];
   references: string[];
-};
-
-export type Chain = {
-  metadata: Metadata;
-  precompiles: (Precompile | Predeploy)[];
-  opcodes: Opcode[];
 };

--- a/src/types/precompiles.ts
+++ b/src/types/precompiles.ts
@@ -1,0 +1,25 @@
+import { Address } from 'viem';
+
+export type PrecompileParam = {
+  byteStart: number;
+  byteLength: number;
+  name: string;
+  description: string;
+};
+
+export type Precompile = {
+  address: Address;
+  name: string;
+  description: string;
+  minGas: number;
+  input: PrecompileParam[];
+  output: PrecompileParam[];
+  references: string[];
+};
+
+export type Predeploy = {
+  address: Address;
+  name: string;
+  description: string;
+  deprecated: boolean;
+};


### PR DESCRIPTION
## Description

Note: this PR should be merged after #12 

To keep the repository simple and well organised, I moved the types defined in `src/chains/types.ts` to their own module `src/types`. In this folder, each type has its own file, e.g. `src/types/opcode.ts`.

```sh
$ tree src/types
src/types
├── chain.ts
├── opcode.ts
└── precompiles.ts

1 directory, 3 files
```

## Test

```sh
$ pnpm fmt:check
> evm-diff@0.1.0 fmt:check /Users/leovct/Documents/opensource/evm-diff
> prettier --check .

Checking formatting...
All matched files use Prettier code style!

$ pnpm build
> evm-diff@0.1.0 build /Users/leovct/Documents/opensource/evm-diff
> next build

info  - Linting and checking validity of types  
info  - Creating an optimized production build  
info  - Compiled successfully
info  - Collecting page data  
info  - Generating static pages (4/4)
info  - Finalizing page optimization  

Route (pages)                              Size     First Load JS
┌ ○ /                                      558 B          99.7 kB
├   /_app                                  0 B            83.3 kB
├ ○ /404                                   182 B          83.4 kB
└ ○ /diff                                  21.1 kB         120 kB
+ First Load JS shared by all              88.1 kB
  ├ chunks/framework-cda45640750da278.js   45.2 kB
  ├ chunks/main-1e0620acb78b93fb.js        26.8 kB
  ├ chunks/pages/_app-47443414f282c22a.js  9.57 kB
  ├ chunks/webpack-52a83b85e685af40.js     1.61 kB
  └ css/a7410964315e4c62.css               4.88 kB

○  (Static)  automatically rendered as static HTML (uses no initial props)
```