### PR TITLE
feat: signature (transaction) types

### DIFF
--- a/src/chains/arbitrum/index.ts
+++ b/src/chains/arbitrum/index.ts
@@ -1,8 +1,11 @@
 import { arbitrum as arbitrumMetadata } from '@wagmi/chains';
 import { Chain } from '@/chains';
+import { sortedArrayByField } from '@/lib/utils';
+import { signatureTypes } from './signatureTypes';
 import { precompiles } from './vm/precompiles';
 
 export const arbitrum: Chain = {
   metadata: arbitrumMetadata,
   precompiles,
+  signatureTypes: sortedArrayByField(signatureTypes, 'prefixByte'),
 };

--- a/src/chains/arbitrum/signatureTypes.ts
+++ b/src/chains/arbitrum/signatureTypes.ts
@@ -11,8 +11,8 @@ const arbitrumDepositTx: SignatureType = {
   signs: 'transaction',
   references: [
     txTypeDocs,
-    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/transaction.go#L48',
-    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/arb_types.go#L338-L344',
+    'https://github.com/OffchainLabs/go-ethereum/blob/dcd0ff9ad8b4c84a9456c6b37f9047233adf7181/core/types/transaction.go#L48',
+    'https://github.com/OffchainLabs/go-ethereum/blob/dcd0ff9ad8b4c84a9456c6b37f9047233adf7181/core/types/arb_types.go#L371-L377',
   ],
 };
 
@@ -26,8 +26,8 @@ const arbitrumUnsignedTx: SignatureType = {
   signs: 'transaction',
   references: [
     txTypeDocs,
-    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/transaction.go#L49',
-    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/arb_types.go#L43-L53',
+    'https://github.com/OffchainLabs/go-ethereum/blob/dcd0ff9ad8b4c84a9456c6b37f9047233adf7181/core/types/transaction.go#L49',
+    'https://github.com/OffchainLabs/go-ethereum/blob/dcd0ff9ad8b4c84a9456c6b37f9047233adf7181/core/types/arb_types.go#L48-L58',
   ],
 };
 
@@ -41,8 +41,8 @@ const arbitrumContractTx: SignatureType = {
   signs: 'transaction',
   references: [
     txTypeDocs,
-    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/transaction.go#L50',
-    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/arb_types.go#L104-L114',
+    'https://github.com/OffchainLabs/go-ethereum/blob/dcd0ff9ad8b4c84a9456c6b37f9047233adf7181/core/types/transaction.go#L50',
+    'https://github.com/OffchainLabs/go-ethereum/blob/dcd0ff9ad8b4c84a9456c6b37f9047233adf7181/core/types/arb_types.go#L116-L126',
   ],
 };
 
@@ -55,8 +55,8 @@ const arbitrumSubmitRetryableTx: SignatureType = {
   signs: 'transaction',
   references: [
     txTypeDocs,
-    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/transaction.go#L52',
-    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/arb_types.go#L232-L247',
+    'https://github.com/OffchainLabs/go-ethereum/blob/dcd0ff9ad8b4c84a9456c6b37f9047233adf7181/core/types/transaction.go#L52',
+    'https://github.com/OffchainLabs/go-ethereum/blob/dcd0ff9ad8b4c84a9456c6b37f9047233adf7181/core/types/arb_types.go#L258-L273',
   ],
 };
 
@@ -70,8 +70,8 @@ const arbitrumRetryTx: SignatureType = {
   signs: 'transaction',
   references: [
     txTypeDocs,
-    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/transaction.go#L51',
-    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/arb_types.go#L161-L176',
+    'https://github.com/OffchainLabs/go-ethereum/blob/dcd0ff9ad8b4c84a9456c6b37f9047233adf7181/core/types/transaction.go#L51',
+    'https://github.com/OffchainLabs/go-ethereum/blob/dcd0ff9ad8b4c84a9456c6b37f9047233adf7181/core/types/arb_types.go#L180-L194',
   ],
 };
 
@@ -82,8 +82,8 @@ const arbitrumInternalTx: SignatureType = {
   signs: 'transaction',
   references: [
     txTypeDocs,
-    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/transaction.go#L53',
-    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/arb_types.go#L387-L390',
+    'https://github.com/OffchainLabs/go-ethereum/blob/dcd0ff9ad8b4c84a9456c6b37f9047233adf7181/core/types/transaction.go#L53',
+    'https://github.com/OffchainLabs/go-ethereum/blob/dcd0ff9ad8b4c84a9456c6b37f9047233adf7181/core/types/arb_types.go#L424-L427',
   ],
 };
 

--- a/src/chains/arbitrum/signatureTypes.ts
+++ b/src/chains/arbitrum/signatureTypes.ts
@@ -1,0 +1,110 @@
+import { SignatureType } from '@/chains';
+import { signatureTypes as mainnetSignatureTypes } from '@/chains/mainnet/signatureTypes';
+
+const txTypeDocs = 'https://developer.arbitrum.io/arbos/geth#transaction-types';
+
+const arbitrumDepositTx: SignatureType = {
+  prefixByte: 0x64,
+  description:
+    "Represents a user deposit from L1 to L2. This increases the user's balance by the amount deposited on L1.",
+  signedData: ['keccak256(0x64 || rlp([chainId, l1RequestId, from, to, value]))'],
+  signs: 'transaction',
+  references: [
+    txTypeDocs,
+    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/transaction.go#L48',
+    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/arb_types.go#L338-L344',
+  ],
+};
+
+const arbitrumUnsignedTx: SignatureType = {
+  prefixByte: 0x65,
+  description:
+    "A message from a user on L1 to a contract on L2 that uses the bridge for authentication instead of requiring the user's signature.",
+  signedData: [
+    'keccak256(0x65 || rlp([chainId, from, nonce, maxFeePerGas, gasLimit, to, value, data]))',
+  ],
+  signs: 'transaction',
+  references: [
+    txTypeDocs,
+    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/transaction.go#L49',
+    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/arb_types.go#L43-L53',
+  ],
+};
+
+const arbitrumContractTx: SignatureType = {
+  prefixByte: 0x66,
+  description:
+    "Similar to an `ArbitrumUnsignedTx` but intended for smart contracts. Uses the bridge's unique, sequential nonce rather than requiring the caller specify their own.",
+  signedData: [
+    'keccak256(0x66 || rlp([chainId, requestId, from, maxFeePerGas, gasLimit, to, value, data]))',
+  ],
+  signs: 'transaction',
+  references: [
+    txTypeDocs,
+    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/transaction.go#L50',
+    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/arb_types.go#L104-L114',
+  ],
+};
+
+const arbitrumSubmitRetryableTx: SignatureType = {
+  prefixByte: 0x69,
+  description: 'A retryable submission and may schedule an ArbitrumRetryTx if provided enough gas.',
+  signedData: [
+    'keccak256(0x69 || rlp([chainId, requestId, from, l1BaseFee, depositValue, maxFeePerGas, gasLimit, retryTo, retryValue, beneficiary, maxSubmissionFee, feeRefundAddress, retryData]))',
+  ],
+  signs: 'transaction',
+  references: [
+    txTypeDocs,
+    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/transaction.go#L52',
+    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/arb_types.go#L232-L247',
+  ],
+};
+
+const arbitrumRetryTx: SignatureType = {
+  prefixByte: 0x68,
+  description:
+    'Transactions scheduled by calls to the redeem precompile method and via retryable auto-redemption.',
+  signedData: [
+    'keccak256(0x68 || rlp([chainId, nonce, from, maxFeePerGas, gasLimit, to, value, data, ticketId, refundTo, maxRefund, submissionFeeRefund]))',
+  ],
+  signs: 'transaction',
+  references: [
+    txTypeDocs,
+    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/transaction.go#L51',
+    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/arb_types.go#L161-L176',
+  ],
+};
+
+const arbitrumInternalTx: SignatureType = {
+  prefixByte: 0x6a,
+  description: 'ArbOS-created transaction to update state between user-generated transactions.',
+  signedData: ['keccak256(0x6a || rlp([chainId, data]))'],
+  signs: 'transaction',
+  references: [
+    txTypeDocs,
+    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/transaction.go#L53',
+    'https://github.com/OffchainLabs/go-ethereum/blob/master/core/types/arb_types.go#L387-L390',
+  ],
+};
+
+const arbitrumLegacyTx: SignatureType = {
+  prefixByte: 0x78,
+  description: 'A legacy transaction',
+  signedData: mainnetSignatureTypes[0x00].signedData,
+  signs: 'transaction',
+  references: [
+    'https://github.com/OffchainLabs/go-ethereum/blob/a2132df21812259f604855f8ae399745fa9b6de6/core/types/transaction.go#L54',
+    ...mainnetSignatureTypes[0x00].references,
+  ],
+};
+
+export const signatureTypes = {
+  ...mainnetSignatureTypes,
+  ...{ [arbitrumDepositTx.prefixByte]: arbitrumDepositTx },
+  ...{ [arbitrumUnsignedTx.prefixByte]: arbitrumUnsignedTx },
+  ...{ [arbitrumContractTx.prefixByte]: arbitrumContractTx },
+  ...{ [arbitrumSubmitRetryableTx.prefixByte]: arbitrumSubmitRetryableTx },
+  ...{ [arbitrumRetryTx.prefixByte]: arbitrumRetryTx },
+  ...{ [arbitrumInternalTx.prefixByte]: arbitrumInternalTx },
+  ...{ [arbitrumLegacyTx.prefixByte]: arbitrumLegacyTx },
+};

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -2,5 +2,5 @@ import { arbitrum } from '@/chains/arbitrum';
 import { mainnet } from '@/chains/mainnet';
 import { optimism } from '@/chains/optimism';
 
-export type { Chain, Precompile, Predeploy } from '@/chains/types';
+export type { Chain, Precompile, Predeploy, SignatureType } from '@/chains/types';
 export const chains = { arbitrum, mainnet, optimism };

--- a/src/chains/mainnet/index.ts
+++ b/src/chains/mainnet/index.ts
@@ -1,10 +1,11 @@
 import { mainnet as mainnetMetadata } from '@wagmi/chains';
 import { Chain } from '@/chains';
+import { sortedArrayByField } from '@/lib/utils';
 import { signatureTypes } from './signatureTypes';
 import { precompiles } from './vm/precompiles';
 
 export const mainnet: Chain = {
   metadata: mainnetMetadata,
   precompiles,
-  signatureTypes,
+  signatureTypes: sortedArrayByField(signatureTypes, 'prefixByte'),
 };

--- a/src/chains/mainnet/index.ts
+++ b/src/chains/mainnet/index.ts
@@ -1,8 +1,10 @@
 import { mainnet as mainnetMetadata } from '@wagmi/chains';
 import { Chain } from '@/chains';
+import { signatureTypes } from './signatureTypes';
 import { precompiles } from './vm/precompiles';
 
 export const mainnet: Chain = {
   metadata: mainnetMetadata,
   precompiles,
+  signatureTypes,
 };

--- a/src/chains/mainnet/signatureTypes.ts
+++ b/src/chains/mainnet/signatureTypes.ts
@@ -2,7 +2,7 @@ import { SignatureType } from '@/chains';
 
 const eip2718 = 'https://eips.ethereum.org/EIPS/eip-2718';
 const sigTypes =
-  'https://github.com/ethereum/execution-specs/blob/master/lists/signature-types/README.md';
+  'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/lists/signature-types/README.md';
 
 // Some signature prefix bytes are invalid because they collide with the initial byte of valid RLP
 // encoded transactions. The range of invalid prefix bytes is 0xc0-0xff, which is a length of 64.

--- a/src/chains/mainnet/signatureTypes.ts
+++ b/src/chains/mainnet/signatureTypes.ts
@@ -1,0 +1,73 @@
+import { SignatureType } from '@/chains';
+
+const eip2718 = 'https://eips.ethereum.org/EIPS/eip-2718';
+const sigTypes =
+  'https://github.com/ethereum/execution-specs/blob/master/lists/signature-types/README.md';
+
+// Some signature prefix bytes are invalid because they collide with the initial byte of valid RLP
+// encoded transactions. The range of invalid prefix bytes is 0xc0-0xff, which is a length of 64.
+const invalidSigTypes: SignatureType[] = [...Array(64).keys()].map((i) => ({
+  prefixByte: i + 0xc0,
+  description: 'Invalid; collides with the initial byte of valid RLP encoded transactions',
+  signedData: undefined,
+  signs: undefined,
+  references: [sigTypes],
+}));
+
+export const validSigTypes: SignatureType[] = [
+  {
+    prefixByte: 0x0,
+    description: 'Legacy (untyped) transaction',
+    signedData: [
+      'keccak256(rlp([nonce, gasPrice, gasLimit, to, value, data]))',
+      'keccak256(rlp([nonce, gasPrice, gasLimit, to, value, data, chainId, 0, 0]))',
+    ],
+    signs: 'transaction',
+    references: ['https://eips.ethereum.org/EIPS/eip-155', eip2718, sigTypes],
+    notes: [
+      "When signing over chain ID, the signature's v-value is computed as `{0,1} + chainId * 2 + 35`, where 0 and 1 are signature's y-parity.",
+    ],
+  },
+  {
+    prefixByte: 0x1,
+    description: 'EIP-2930 Access list transaction',
+    signedData: [
+      'keccak256(0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList]))',
+    ],
+    signs: 'transaction',
+    references: ['https://eips.ethereum.org/EIPS/eip-2930', eip2718, sigTypes],
+  },
+  {
+    prefixByte: 0x2,
+    description: 'EIP-1559 transaction',
+    signedData: [
+      'keccak256(0x02 || rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList]))',
+    ],
+    signs: 'transaction',
+    references: ['https://eips.ethereum.org/EIPS/eip-1559', eip2718, sigTypes],
+  },
+  {
+    prefixByte: 0x3,
+    description: 'Unused, but tentatively reserved for EIP-3074',
+    signedData: ['keccak256(0x03 || chainId || paddedInvokerAddress || commit)'],
+    signs: 'transaction',
+    references: ['https://eips.ethereum.org/EIPS/eip-3074', eip2718, sigTypes],
+  },
+  {
+    prefixByte: 0x19,
+    description:
+      'Used for signatures of data payloads to prevent collisions between data signatures and transaction signatures',
+    signedData: ['keccak256(0x19 || 1-byte-version || versionSpecificData || dataToSign)'],
+    signs: 'data',
+    references: ['https://eips.ethereum.org/EIPS/eip-191', sigTypes],
+  },
+  ...invalidSigTypes,
+];
+
+const allSigTypes = [...validSigTypes, ...invalidSigTypes];
+
+// Reshape into a map where the key is the prefix byte.
+export const signatureTypes: Record<number, SignatureType> = allSigTypes.reduce((acc, sigType) => {
+  acc[sigType.prefixByte] = sigType;
+  return acc;
+}, {} as Record<number, SignatureType>);

--- a/src/chains/mainnet/vm/precompiles.ts
+++ b/src/chains/mainnet/vm/precompiles.ts
@@ -41,9 +41,9 @@ export const precompiles: Precompile[] = [
       },
     ],
     references: [
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/ecrecover.py',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/gas.py#L50',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L30',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/ecrecover.py',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/gas.py#L50',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L30',
     ],
     notes: [
       "If an address cannot be recovered, or not enough gas was given, then there is no return data. Note that the return data is the address that issued the signature but it won't verify the signature.",
@@ -71,9 +71,9 @@ export const precompiles: Precompile[] = [
       },
     ],
     references: [
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/sha256.py',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/gas.py#L51',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L31',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/sha256.py',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/gas.py#L51',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L31',
     ],
     notes: ['If not enough gas was given, then there is no return data.'],
   },
@@ -99,9 +99,9 @@ export const precompiles: Precompile[] = [
       },
     ],
     references: [
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/ripemd160.py',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/gas.py#L53',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L32',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/ripemd160.py',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/gas.py#L53',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L32',
     ],
     notes: ['If not enough gas was given, then there is no return data.'],
   },
@@ -127,9 +127,9 @@ export const precompiles: Precompile[] = [
       },
     ],
     references: [
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/identity.py',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/gas.py#L55',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L33',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/identity.py',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/gas.py#L55',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L33',
     ],
     notes: [
       'If not enough gas was given, then there is no return data.',
@@ -188,9 +188,9 @@ export const precompiles: Precompile[] = [
       },
     ],
     references: [
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/modexp.py',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/modexp.py#L167',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L34',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/modexp.py',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/modexp.py#L167',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L34',
     ],
     notes: ['If not enough gas was given, then there is no return data.'],
   },
@@ -240,9 +240,9 @@ export const precompiles: Precompile[] = [
       },
     ],
     references: [
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/alt_bn128.py#L33',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/alt_bn128.py#L45',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L35',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/alt_bn128.py#L33',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/alt_bn128.py#L45',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L35',
     ],
     notes: [
       'If the input is not valid, or if not enough gas was given, then there is no return data.',
@@ -290,9 +290,9 @@ export const precompiles: Precompile[] = [
       },
     ],
     references: [
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/alt_bn128.py#L72',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/alt_bn128.py#L84',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L36',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/alt_bn128.py#L72',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/alt_bn128.py#L84',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L36',
     ],
     notes: [
       'If the input is not valid, or if not enough gas was given, then there is no return data.',
@@ -354,9 +354,9 @@ export const precompiles: Precompile[] = [
       },
     ],
     references: [
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/alt_bn128.py#L107',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/alt_bn128.py#L119',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L37',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/alt_bn128.py#L107',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/alt_bn128.py#L119',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L37',
     ],
     notes: [
       'The input must always be a multiple of 6 32-byte values. 0 inputs is valid and returns 1.',
@@ -414,9 +414,9 @@ export const precompiles: Precompile[] = [
       'Of the input does not allow to compute a valid result, all the gas sent is consumed.',
     ],
     references: [
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/blake2f.py',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/gas.py#L59',
-      'https://github.com/ethereum/execution-specs/blob/master/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L38',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/blake2f.py',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/gas.py#L59',
+      'https://github.com/ethereum/execution-specs/blob/6f8614566e7117afa327ad054c3f4bfe19694d73/src/ethereum/shanghai/vm/precompiled_contracts/__init__.py#L38',
     ],
   },
 ];

--- a/src/chains/optimism/index.ts
+++ b/src/chains/optimism/index.ts
@@ -1,8 +1,11 @@
 import { optimism as optimismMetadata } from '@wagmi/chains';
 import { Chain } from '@/chains';
+import { sortedArrayByField } from '@/lib/utils';
+import { signatureTypes } from './signatureTypes';
 import { precompiles } from './vm/precompiles';
 
 export const optimism: Chain = {
   metadata: optimismMetadata,
   precompiles,
+  signatureTypes: sortedArrayByField(signatureTypes, 'prefixByte'),
 };

--- a/src/chains/optimism/signatureTypes.ts
+++ b/src/chains/optimism/signatureTypes.ts
@@ -1,0 +1,25 @@
+import { SignatureType } from '@/chains';
+import { signatureTypes as mainnetSignatureTypes } from '@/chains/mainnet/signatureTypes';
+
+const depositTx: SignatureType = {
+  prefixByte: 0x7e,
+  description: 'An L2 transaction that was derived from L1 and included in a L2 block',
+  signedData: [
+    'keccak256(0x7E || rlp([sourceHash, from, to, mint, value, gas, isSystemTx, data]))',
+  ],
+  signs: 'transaction',
+  references: [
+    'https://github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md#the-deposited-transaction-type',
+    'https://github.com/ethereum-optimism/optimism/blob/develop/specs/glossary.md#deposited-transaction',
+  ],
+  notes: [
+    `There are two kinds of deposited transactions:
+- [L1 attributes deposited transaction][l1-attr-deposit], which submits the L1 block's attributes to the [L1 Attributes Predeployed Contract][l1-attr-predeploy].
+- [User-deposited transactions][user-deposited], which are transactions derived from an L1 call to the [deposit contract][deposit-contract].`,
+  ],
+};
+
+export const signatureTypes = {
+  ...mainnetSignatureTypes,
+  ...{ [depositTx.prefixByte]: depositTx },
+};

--- a/src/chains/types.ts
+++ b/src/chains/types.ts
@@ -1,6 +1,17 @@
 import { Chain as Metadata } from '@wagmi/chains';
 import { Address } from 'viem';
 
+export type SignatureType = {
+  prefixByte: number;
+  description: string;
+  // The data that is RLP encoded and signed to generate a signed transaction.
+  signedData: string[] | undefined;
+  // Some signature types are used to sign transactions, others are used to sign data.
+  signs: 'transaction' | 'data' | undefined;
+  references: string[];
+  notes?: string[];
+};
+
 type PrecompileParam = {
   byteStart: number | string;
   byteLength: number | string;
@@ -29,4 +40,5 @@ export type Precompile = {
 export type Chain = {
   metadata: Metadata;
   precompiles: (Precompile | Predeploy)[];
+  signatureTypes: SignatureType[];
 };

--- a/src/components/diff/DiffSignatureTypes.tsx
+++ b/src/components/diff/DiffSignatureTypes.tsx
@@ -1,0 +1,54 @@
+import { pad } from 'viem';
+import { SignatureType } from '@/chains';
+
+type Props = {
+  base: SignatureType[];
+  target: SignatureType[];
+  onlyShowDiff: boolean;
+};
+
+const formatSigType = (contents: SignatureType | undefined) => {
+  if (!contents) return <p>Not present</p>;
+  return (
+    <>
+      <p>{contents.description}</p>
+      <p className='text-secondary text-sm'>{contents.signedData}</p>
+    </>
+  );
+};
+
+// Returns a hex string with a leading `0x` and padded to 2 characters.
+const formatPrefixByte = (prefix: number) => {
+  return pad(`0x${prefix.toString(16).toUpperCase()}`, { size: 1 });
+};
+
+export const DiffSignatureTypes = ({ base, target, onlyShowDiff }: Props) => {
+  // Generate a sorted list of all transaction types from both base and target.
+  const allPrefixBytes = [...base.map((t) => t.prefixByte), ...target.map((t) => t.prefixByte)];
+  const prefixBytes = [...new Set(allPrefixBytes.sort((a, b) => a - b))];
+
+  return (
+    <>
+      {prefixBytes.map((prefix) => {
+        const baseSigType = base.find((s) => s.prefixByte === prefix);
+        const targetSigType = target.find((s) => s.prefixByte === prefix);
+
+        const isEqual = JSON.stringify(baseSigType) === JSON.stringify(targetSigType);
+        const showSigType = !isEqual || !onlyShowDiff;
+
+        return (
+          showSigType && (
+            <div
+              key={prefix}
+              className='flex items-center justify-between border-b border-zinc-500/10 py-1 dark:border-zinc-500/20'
+            >
+              <div className='flex-1'>{formatSigType(baseSigType)}</div>
+              <div className='flex-1 text-center'>{formatPrefixByte(prefix)}</div>
+              <div className='flex-1'>{formatSigType(targetSigType)}</div>
+            </div>
+          )
+        );
+      })}
+    </>
+  );
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,1 +1,16 @@
+// Takes an arbitrary number of class names, filtering out any falsey values.
 export const classNames = (...classes: (string | boolean)[]) => classes.filter(Boolean).join(' ');
+
+// Given a `record` (i.e. an object), return an array of its values sorted by the given `field`.
+// Make sure the field is a number or string or the sort behavior based on `>` and `<` may be
+// undefined.
+export const sortedArrayByField = <T extends number | string | symbol, U, K extends keyof U>(
+  record: Record<T, U>,
+  field: K
+): U[] => {
+  return (Object.values(record) as U[]).sort((a, b) => {
+    if (a[field] > b[field]) return 1;
+    if (a[field] < b[field]) return -1;
+    return 0;
+  });
+};

--- a/src/pages/diff.tsx
+++ b/src/pages/diff.tsx
@@ -4,7 +4,14 @@ import { Chain, chains } from '@/chains';
 import { ChainDiffSelector } from '@/components/ChainDiffSelector';
 import { DiffMetadata } from '@/components/diff/DiffMetadata';
 import { DiffPrecompiles } from '@/components/diff/DiffPrecompiles';
+import { DiffSignatureTypes } from '@/components/diff/DiffSignatureTypes';
 import { Toggle } from '@/components/ui/Toggle';
+
+const SECTION_MAP: Record<string, string> = {
+  metadata: 'Metadata',
+  precompiles: 'Precompiles and Predeploys',
+  signatureTypes: 'Transaction and Signature Types',
+};
 
 const Diff = () => {
   // -------- Parse query parameters --------
@@ -43,17 +50,11 @@ const Diff = () => {
 
   const [onlyShowDiff, setOnlyShowDiff] = useState(true);
 
-  const SectionHeader = ({ section }: { section: string }) => {
-    if (section === 'metadata') section = 'Metadata';
-    else if (section === 'precompiles') section = 'Precompiles and Predeploys';
-
-    return (
-      <h2 className='border-b border-zinc-500/10 text-center font-bold dark:border-zinc-500/20'>
-        {section}
-      </h2>
-    );
-  };
-
+  const SectionHeader = ({ section }: { section: string }) => (
+    <h2 className='border-b border-zinc-500/10 text-center font-bold dark:border-zinc-500/20'>
+      {SECTION_MAP[section] || section}
+    </h2>
+  );
   // We take `baseChain` and `targetChain` as arguments to ensure that they are not `undefined`
   // and remove the need for `?` and `!` operators.
   const DiffDiv = ({ baseChain, targetChain }: { baseChain: Chain; targetChain: Chain }) => {
@@ -78,6 +79,14 @@ const Diff = () => {
               <DiffPrecompiles
                 base={baseChain.precompiles}
                 target={targetChain.precompiles}
+                onlyShowDiff={onlyShowDiff}
+              />
+            );
+          } else if (section === 'signatureTypes') {
+            content = (
+              <DiffSignatureTypes
+                base={baseChain.signatureTypes}
+                target={targetChain.signatureTypes}
                 onlyShowDiff={onlyShowDiff}
               />
             );


### PR DESCRIPTION
Adds EIP-2718 transaction and signature types for mainnet, arbitrum, and optimism, along with a basic rendering of their diff. Showing more detailed info in the diff + style improvements will come in a future PR.

One thing currently implied is that both arbitrum and optimism both consider prefix byte 0x03 reserved and will not use it. Optimism's [spec](https://github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md#the-deposited-transaction-type) for the Deposited Transaction type suggests they'll avoid using that prefix byte:

> Picking a high identifier minimizes the risk that the identifier will be used be claimed by another transaction type on the L1 chain in the future.

I couldn't explicitly find anything similar for Arbitrum, but given that their new transaction types also use high identifiers, I imagine they also don't plan to use it