### PR TITLE
fix: attempt to fix social previews, fix build warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "fmt:check": "prettier --check ."
   },
   "dependencies": {
-    "@headlessui/react": "^1.7.14",
+    "@headlessui/react": "^1.7.16",
     "@heroicons/react": "^2.0.17",
     "@vercel/analytics": "^1.0.1",
     "@vercel/og": "^0.5.10",
     "@wagmi/chains": "^0.3.1",
-    "next": "13.4.12",
+    "next": "^13.4.12",
     "next-themes": "^0.2.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@headlessui/react':
-    specifier: ^1.7.14
-    version: 1.7.14(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^1.7.16
+    version: 1.7.16(react-dom@18.2.0)(react@18.2.0)
   '@heroicons/react':
     specifier: ^2.0.17
     version: 2.0.17(react@18.2.0)
@@ -21,7 +21,7 @@ dependencies:
     specifier: ^0.3.1
     version: 0.3.1(typescript@5.0.4)
   next:
-    specifier: 13.4.12
+    specifier: ^13.4.12
     version: 13.4.12(react-dom@18.2.0)(react@18.2.0)
   next-themes:
     specifier: ^0.2.1
@@ -261,8 +261,8 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@headlessui/react@1.7.14(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-znzdq9PG8rkwcu9oQ2FwIy0ZFtP9Z7ycS+BAqJ3R5EIqC/0bJGvhT7193rFf+45i9nnPsYvCQVW4V/bB9Xc+gA==}
+  /@headlessui/react@1.7.16(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-2MphIAZdSUacZBT6EXk8AJkj+EuvaaJbtCyHTJrPsz8inhzCl7qeNPI1uk1AUvCgWylVtdN8cVVmnhUDPxPy3g==}
     engines: {node: '>=10'}
     peerDependencies:
       react: ^16 || ^17 || ^18

--- a/src/components/layout/Head.tsx
+++ b/src/components/layout/Head.tsx
@@ -1,5 +1,6 @@
 import NextHead from 'next/head';
 import { NextRouter, useRouter } from 'next/router';
+import { getChainById } from '@/chains';
 import {
   COMPANY_URL,
   OG_ENDPOINT,
@@ -10,28 +11,36 @@ import {
 } from '@/lib/constants';
 
 // Function to generate the query parameter string based on base and target values.
-const getImageUrl = (router: NextRouter) => {
+const getRouteData = (router: NextRouter) => {
+  const defaultRouteData = { title: SITE_NAME, imageUrl: '' };
   const path = router.pathname;
   if (path === '/diff') {
     const { base, target } = router.query;
-    if (!base && !target) return '';
-    return `?base=${base}&target=${target}`;
+    if (!base || !target) defaultRouteData;
+
+    const baseTitle = getChainById(base as string)?.metadata.name;
+    const targetTitle = getChainById(target as string)?.metadata.name;
+    if (!baseTitle || !targetTitle) return defaultRouteData;
+
+    const title = `${baseTitle} vs ${targetTitle} | ${SITE_NAME}`;
+    const imageUrl = `?base=${base}&target=${target}`;
+    return { title, imageUrl };
   }
-  return '';
+  return defaultRouteData;
 };
 
-export const Head = ({ title, description }: { title?: string; description?: string }) => {
+export const Head = () => {
   const router = useRouter();
-  const adjustedTitle = title ? `${title} | ${SITE_NAME}` : SITE_NAME;
-  const imgUrl = `${SITE_URL}${OG_ENDPOINT}${getImageUrl(router)}`;
+  const { title, imageUrl } = getRouteData(router);
+  const imgUrl = `${SITE_URL}${OG_ENDPOINT}${imageUrl}`;
 
   return (
     <NextHead>
-      <title>{adjustedTitle}</title>
-      <meta name='description' content={description ?? SITE_DESCRIPTION} />
+      <title>{title}</title>
+      <meta name='description' content={SITE_DESCRIPTION} />
       <meta name='viewport' content='width=device-width, initial-scale=1' />
 
-      <meta property='og:title' content={adjustedTitle} />
+      <meta property='og:title' content={title} />
       <meta property='og:description' content={SITE_DESCRIPTION} />
       <meta property='og:type' content='website' />
       <meta property='og:url' content={SITE_URL} />

--- a/src/components/ui/Copyable.tsx
+++ b/src/components/ui/Copyable.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Transition } from '@headlessui/react';
 import { ClipboardDocumentIcon } from '@heroicons/react/24/outline';
 import { classNames, copyToClipboard } from '@/lib/utils';
 import { Tooltip } from './Tooltip';
@@ -43,17 +42,11 @@ export const Copyable = ({
           className='ml-2 h-4 cursor-pointer opacity-0 transition-opacity group-hover:opacity-100'
         />
       </div>
-      <Transition
-        show={isShowing}
-        enter='transition-opacity duration-75'
-        enterFrom='opacity-0'
-        enterTo='opacity-100'
-        leave='transition-opacity duration-150'
-        leaveFrom='opacity-100'
-        leaveTo='opacity-0'
+      <div
+        className={classNames(isShowing ? 'opacity-100' : 'opacity-0', 'transition duration-150')}
       >
         <Tooltip text='Copied!' showIcon={false} />
-      </Transition>
+      </div>
     </div>
   );
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,6 +3,7 @@ import type { AppProps } from 'next/app';
 import { Open_Sans } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/react';
 import { ThemeProvider } from 'next-themes';
+import { Head } from '@/components/layout/Head';
 import { Layout } from '@/components/layout/Layout';
 import '@/styles/globals.css';
 
@@ -13,6 +14,7 @@ function App({ Component, pageProps }: AppProps) {
   React.useEffect(() => setMounted(true), []);
   return (
     <ThemeProvider attribute='class'>
+      <Head />
       {mounted && (
         <Layout>
           <div className={font.className}>

--- a/src/pages/diff.tsx
+++ b/src/pages/diff.tsx
@@ -8,7 +8,6 @@ import { DiffOpcodes } from '@/components/diff/DiffOpcodes';
 import { DiffPrecompiles } from '@/components/diff/DiffPrecompiles';
 import { DiffPredeploys } from '@/components/diff/DiffPredeploys';
 import { DiffSignatureTypes } from '@/components/diff/DiffSignatureTypes';
-import { Head } from '@/components/layout/Head';
 import { Copyable } from '@/components/ui/Copyable';
 import { Toggle } from '@/components/ui/Toggle';
 import { classNames } from '@/lib/utils';
@@ -80,7 +79,6 @@ const Diff = () => {
     const sections = Object.keys(baseChain);
     return (
       <>
-        <Head title={`${baseChain.metadata.name} vs. ${targetChain.metadata.name}`} />
         <main>
           <Toggle
             enabled={onlyShowDiff}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,9 @@
 import { ChainDiffSelector } from '@/components/ChainDiffSelector';
-import { Head } from '@/components/layout/Head';
 import { SITE_DESCRIPTION } from '@/lib/constants';
 
 const Home = () => {
   return (
     <>
-      <Head />
       <main className='mx-auto max-w-7xl sm:px-6 lg:px-8'>
         <div className='relative isolate overflow-hidden px-6 py-0 sm:rounded-3xl sm:px-24 sm:py-20'>
           <h2 className='mx-auto max-w-2xl text-center text-3xl font-bold tracking-tight text-zinc-1000 dark:text-zinc-0 sm:text-4xl'>


### PR DESCRIPTION
1. Attempt to fix social previews not working:  The meta tags are not present on the HTML returned by the server so no image is found. I think this is because the Head component was rendered per-page and therefore required JS to render. Here we move it to the root `_app.tsx` and everything is dynamically rendered in the Head component based on the route.
2. Fix build error on node vs. edge differences: The error was: `A Node.js API is used (MessageChannel at line: 121) which is not supported in the Edge Runtime`. This was tracked down to the headlessui `Transition` component in `Copyable.tsx`, so we remove that and use a manual transition instead. I think this only showed up after the prior change, presumably because now more rendering happens on the server (which is what we want)