### PR TITLE
style: diff improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "next-themes": "^0.2.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-markdown": "^8.0.7",
     "viem": "^1.5.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ dependencies:
   react-dom:
     specifier: 18.2.0
     version: 18.2.0(react@18.2.0)
+  react-markdown:
+    specifier: ^8.0.7
+    version: 8.0.7(@types/react@18.2.5)(react@18.2.0)
   viem:
     specifier: ^1.5.0
     version: 1.5.0(typescript@5.0.4)
@@ -541,6 +544,18 @@ packages:
       - supports-color
     dev: true
 
+  /@types/debug@4.1.8:
+    resolution: {integrity: sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==}
+    dependencies:
+      '@types/ms': 0.7.31
+    dev: false
+
+  /@types/hast@2.3.5:
+    resolution: {integrity: sha512-SvQi0L/lNpThgPoleH53cdjB3y9zpLlVjRbqB3rH8hx1jiRSBGAhyjV3H+URFjNVRqt2EdYNrbZE5IsGlNfpRg==}
+    dependencies:
+      '@types/unist': 2.0.7
+    dev: false
+
   /@types/json-schema@7.0.12:
     resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
     dev: true
@@ -549,13 +564,22 @@ packages:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: true
 
+  /@types/mdast@3.0.12:
+    resolution: {integrity: sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==}
+    dependencies:
+      '@types/unist': 2.0.7
+    dev: false
+
+  /@types/ms@0.7.31:
+    resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
+    dev: false
+
   /@types/node@18.16.3:
     resolution: {integrity: sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==}
     dev: true
 
   /@types/prop-types@15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
-    dev: true
 
   /@types/react-dom@18.2.3:
     resolution: {integrity: sha512-hxXEXWxFJXbY0LMj/T69mznqOZJXNtQMqVxIiirVAZnnpeYiD4zt+lPsgcr/cfWg2VLsxZ1y26vigG03prYB+Q==}
@@ -569,15 +593,17 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.3
       csstype: 3.1.2
-    dev: true
 
   /@types/scheduler@0.16.3:
     resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
-    dev: true
 
   /@types/semver@7.5.0:
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
     dev: true
+
+  /@types/unist@2.0.7:
+    resolution: {integrity: sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==}
+    dev: false
 
   /@typescript-eslint/eslint-plugin@6.1.0(@typescript-eslint/parser@6.1.0)(eslint@8.39.0)(typescript@5.0.4):
     resolution: {integrity: sha512-qg7Bm5TyP/I7iilGyp6DRqqkt8na00lI6HbjWZObgk3FFSzH5ypRwAHXJhJkwiRtTcfn+xYQIMOR5kJgpo6upw==}
@@ -997,6 +1023,10 @@ packages:
       deep-equal: 2.2.1
     dev: true
 
+  /bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+    dev: false
+
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
@@ -1103,6 +1133,10 @@ packages:
       supports-color: 7.2.0
     dev: true
 
+  /character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+    dev: false
+
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
@@ -1151,6 +1185,10 @@ packages:
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  /comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+    dev: false
+
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -1198,7 +1236,6 @@ packages:
 
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
-    dev: true
 
   /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -1225,7 +1262,12 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
+
+  /decode-named-character-reference@1.0.2:
+    resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
+    dependencies:
+      character-entities: 2.0.2
+    dev: false
 
   /deep-equal@2.2.1:
     resolution: {integrity: sha512-lKdkdV6EOGoVn65XaOsPdH4rMxTZOnmFyuIkMjM1i5HHCbfjC97dawgTAy0deYNfuqUqW+Q5VrVaQYtUpSd6yQ==}
@@ -1285,9 +1327,19 @@ packages:
       object-keys: 1.1.1
     dev: true
 
+  /dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+    dev: false
+
   /didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
     dev: true
+
+  /diff@5.1.0:
+    resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
+    engines: {node: '>=0.3.1'}
+    dev: false
 
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -1765,6 +1817,10 @@ packages:
       strip-final-newline: 3.0.0
     dev: true
 
+  /extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    dev: false
+
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: true
@@ -2052,6 +2108,10 @@ packages:
       function-bind: 1.1.1
     dev: true
 
+  /hast-util-whitespace@2.0.1:
+    resolution: {integrity: sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==}
+    dev: false
+
   /hex-rgb@4.3.0:
     resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
     engines: {node: '>=6'}
@@ -2095,6 +2155,10 @@ packages:
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
     dev: true
+
+  /inline-style-parser@0.1.1:
+    resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
+    dev: false
 
   /internal-slot@1.0.5:
     resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
@@ -2141,6 +2205,11 @@ packages:
       call-bind: 1.0.2
       has-tostringtag: 1.0.0
     dev: true
+
+  /is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+    dev: false
 
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -2217,6 +2286,11 @@ packages:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
     dev: true
+
+  /is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+    dev: false
 
   /is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
@@ -2363,6 +2437,11 @@ packages:
       object.assign: 4.1.4
     dev: true
 
+  /kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+    dev: false
+
   /language-subtag-registry@0.3.22:
     resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}
     dev: true
@@ -2425,6 +2504,52 @@ packages:
       yallist: 4.0.0
     dev: true
 
+  /mdast-util-definitions@5.1.2:
+    resolution: {integrity: sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==}
+    dependencies:
+      '@types/mdast': 3.0.12
+      '@types/unist': 2.0.7
+      unist-util-visit: 4.1.2
+    dev: false
+
+  /mdast-util-from-markdown@1.3.1:
+    resolution: {integrity: sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==}
+    dependencies:
+      '@types/mdast': 3.0.12
+      '@types/unist': 2.0.7
+      decode-named-character-reference: 1.0.2
+      mdast-util-to-string: 3.2.0
+      micromark: 3.2.0
+      micromark-util-decode-numeric-character-reference: 1.1.0
+      micromark-util-decode-string: 1.1.0
+      micromark-util-normalize-identifier: 1.1.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+      unist-util-stringify-position: 3.0.3
+      uvu: 0.5.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-to-hast@12.3.0:
+    resolution: {integrity: sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==}
+    dependencies:
+      '@types/hast': 2.3.5
+      '@types/mdast': 3.0.12
+      mdast-util-definitions: 5.1.2
+      micromark-util-sanitize-uri: 1.2.0
+      trim-lines: 3.0.1
+      unist-util-generated: 2.0.1
+      unist-util-position: 4.0.4
+      unist-util-visit: 4.1.2
+    dev: false
+
+  /mdast-util-to-string@3.2.0:
+    resolution: {integrity: sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==}
+    dependencies:
+      '@types/mdast': 3.0.12
+    dev: false
+
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
     dev: true
@@ -2433,6 +2558,181 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
     dev: true
+
+  /micromark-core-commonmark@1.1.0:
+    resolution: {integrity: sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==}
+    dependencies:
+      decode-named-character-reference: 1.0.2
+      micromark-factory-destination: 1.1.0
+      micromark-factory-label: 1.1.0
+      micromark-factory-space: 1.1.0
+      micromark-factory-title: 1.1.0
+      micromark-factory-whitespace: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-chunked: 1.1.0
+      micromark-util-classify-character: 1.1.0
+      micromark-util-html-tag-name: 1.2.0
+      micromark-util-normalize-identifier: 1.1.0
+      micromark-util-resolve-all: 1.1.0
+      micromark-util-subtokenize: 1.1.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-factory-destination@1.1.0:
+    resolution: {integrity: sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==}
+    dependencies:
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+    dev: false
+
+  /micromark-factory-label@1.1.0:
+    resolution: {integrity: sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==}
+    dependencies:
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-factory-space@1.1.0:
+    resolution: {integrity: sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==}
+    dependencies:
+      micromark-util-character: 1.2.0
+      micromark-util-types: 1.1.0
+    dev: false
+
+  /micromark-factory-title@1.1.0:
+    resolution: {integrity: sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==}
+    dependencies:
+      micromark-factory-space: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+    dev: false
+
+  /micromark-factory-whitespace@1.1.0:
+    resolution: {integrity: sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==}
+    dependencies:
+      micromark-factory-space: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+    dev: false
+
+  /micromark-util-character@1.2.0:
+    resolution: {integrity: sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==}
+    dependencies:
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+    dev: false
+
+  /micromark-util-chunked@1.1.0:
+    resolution: {integrity: sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==}
+    dependencies:
+      micromark-util-symbol: 1.1.0
+    dev: false
+
+  /micromark-util-classify-character@1.1.0:
+    resolution: {integrity: sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==}
+    dependencies:
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+    dev: false
+
+  /micromark-util-combine-extensions@1.1.0:
+    resolution: {integrity: sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==}
+    dependencies:
+      micromark-util-chunked: 1.1.0
+      micromark-util-types: 1.1.0
+    dev: false
+
+  /micromark-util-decode-numeric-character-reference@1.1.0:
+    resolution: {integrity: sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==}
+    dependencies:
+      micromark-util-symbol: 1.1.0
+    dev: false
+
+  /micromark-util-decode-string@1.1.0:
+    resolution: {integrity: sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==}
+    dependencies:
+      decode-named-character-reference: 1.0.2
+      micromark-util-character: 1.2.0
+      micromark-util-decode-numeric-character-reference: 1.1.0
+      micromark-util-symbol: 1.1.0
+    dev: false
+
+  /micromark-util-encode@1.1.0:
+    resolution: {integrity: sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==}
+    dev: false
+
+  /micromark-util-html-tag-name@1.2.0:
+    resolution: {integrity: sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==}
+    dev: false
+
+  /micromark-util-normalize-identifier@1.1.0:
+    resolution: {integrity: sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==}
+    dependencies:
+      micromark-util-symbol: 1.1.0
+    dev: false
+
+  /micromark-util-resolve-all@1.1.0:
+    resolution: {integrity: sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==}
+    dependencies:
+      micromark-util-types: 1.1.0
+    dev: false
+
+  /micromark-util-sanitize-uri@1.2.0:
+    resolution: {integrity: sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==}
+    dependencies:
+      micromark-util-character: 1.2.0
+      micromark-util-encode: 1.1.0
+      micromark-util-symbol: 1.1.0
+    dev: false
+
+  /micromark-util-subtokenize@1.1.0:
+    resolution: {integrity: sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==}
+    dependencies:
+      micromark-util-chunked: 1.1.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-util-symbol@1.1.0:
+    resolution: {integrity: sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==}
+    dev: false
+
+  /micromark-util-types@1.1.0:
+    resolution: {integrity: sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==}
+    dev: false
+
+  /micromark@3.2.0:
+    resolution: {integrity: sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==}
+    dependencies:
+      '@types/debug': 4.1.8
+      debug: 4.3.4
+      decode-named-character-reference: 1.0.2
+      micromark-core-commonmark: 1.1.0
+      micromark-factory-space: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-chunked: 1.1.0
+      micromark-util-combine-extensions: 1.1.0
+      micromark-util-decode-numeric-character-reference: 1.1.0
+      micromark-util-encode: 1.1.0
+      micromark-util-normalize-identifier: 1.1.0
+      micromark-util-resolve-all: 1.1.0
+      micromark-util-sanitize-uri: 1.2.0
+      micromark-util-subtokenize: 1.1.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+      uvu: 0.5.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
@@ -2467,9 +2767,13 @@ packages:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
 
+  /mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+    dev: false
+
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: true
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2582,7 +2886,6 @@ packages:
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
@@ -2919,7 +3222,10 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-    dev: true
+
+  /property-information@6.2.0:
+    resolution: {integrity: sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==}
+    dev: false
 
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
@@ -2942,7 +3248,37 @@ packages:
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-    dev: true
+
+  /react-is@18.2.0:
+    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+    dev: false
+
+  /react-markdown@8.0.7(@types/react@18.2.5)(react@18.2.0):
+    resolution: {integrity: sha512-bvWbzG4MtOU62XqBx3Xx+zB2raaFFsq4mYiAzfjXJMEz2sixgeAfraA3tvzULF02ZdOMUOKTBFFaZJDDrq+BJQ==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+    dependencies:
+      '@types/hast': 2.3.5
+      '@types/prop-types': 15.7.5
+      '@types/react': 18.2.5
+      '@types/unist': 2.0.7
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 2.0.1
+      prop-types: 15.8.1
+      property-information: 6.2.0
+      react: 18.2.0
+      react-is: 18.2.0
+      remark-parse: 10.0.2
+      remark-rehype: 10.1.0
+      space-separated-tokens: 2.0.2
+      style-to-object: 0.4.2
+      unified: 10.1.2
+      unist-util-visit: 4.1.2
+      vfile: 5.3.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
@@ -2976,6 +3312,25 @@ packages:
       define-properties: 1.2.0
       functions-have-names: 1.2.3
     dev: true
+
+  /remark-parse@10.0.2:
+    resolution: {integrity: sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==}
+    dependencies:
+      '@types/mdast': 3.0.12
+      mdast-util-from-markdown: 1.3.1
+      unified: 10.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /remark-rehype@10.1.0:
+    resolution: {integrity: sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==}
+    dependencies:
+      '@types/hast': 2.3.5
+      '@types/mdast': 3.0.12
+      mdast-util-to-hast: 12.3.0
+      unified: 10.1.2
+    dev: false
 
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3024,6 +3379,13 @@ packages:
     dependencies:
       queue-microtask: 1.2.3
     dev: true
+
+  /sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+    dependencies:
+      mri: 1.2.0
+    dev: false
 
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
@@ -3111,6 +3473,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+    dev: false
+
   /stop-iteration-iterator@1.0.0:
     resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}
     engines: {node: '>= 0.4'}
@@ -3191,6 +3557,12 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
     dev: true
+
+  /style-to-object@0.4.2:
+    resolution: {integrity: sha512-1JGpfPB3lo42ZX8cuPrheZbfQ6kqPPnPHlKMyeRYtfKD+0jG+QsXgXN57O/dvJlzlB2elI6dGmrPnl5VPQFPaA==}
+    dependencies:
+      inline-style-parser: 0.1.1
+    dev: false
 
   /styled-jsx@5.1.1(react@18.2.0):
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
@@ -3325,6 +3697,14 @@ packages:
       is-number: 7.0.0
     dev: true
 
+  /trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+    dev: false
+
+  /trough@2.1.0:
+    resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
+    dev: false
+
   /ts-api-utils@1.0.1(typescript@5.0.4):
     resolution: {integrity: sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==}
     engines: {node: '>=16.13.0'}
@@ -3405,6 +3785,55 @@ packages:
       tiny-inflate: 1.0.3
     dev: false
 
+  /unified@10.1.2:
+    resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}
+    dependencies:
+      '@types/unist': 2.0.7
+      bail: 2.0.2
+      extend: 3.0.2
+      is-buffer: 2.0.5
+      is-plain-obj: 4.1.0
+      trough: 2.1.0
+      vfile: 5.3.7
+    dev: false
+
+  /unist-util-generated@2.0.1:
+    resolution: {integrity: sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==}
+    dev: false
+
+  /unist-util-is@5.2.1:
+    resolution: {integrity: sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==}
+    dependencies:
+      '@types/unist': 2.0.7
+    dev: false
+
+  /unist-util-position@4.0.4:
+    resolution: {integrity: sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==}
+    dependencies:
+      '@types/unist': 2.0.7
+    dev: false
+
+  /unist-util-stringify-position@3.0.3:
+    resolution: {integrity: sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==}
+    dependencies:
+      '@types/unist': 2.0.7
+    dev: false
+
+  /unist-util-visit-parents@5.1.3:
+    resolution: {integrity: sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==}
+    dependencies:
+      '@types/unist': 2.0.7
+      unist-util-is: 5.2.1
+    dev: false
+
+  /unist-util-visit@4.1.2:
+    resolution: {integrity: sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==}
+    dependencies:
+      '@types/unist': 2.0.7
+      unist-util-is: 5.2.1
+      unist-util-visit-parents: 5.1.3
+    dev: false
+
   /untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
     engines: {node: '>=8'}
@@ -3430,6 +3859,33 @@ packages:
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
+
+  /uvu@0.5.6:
+    resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      dequal: 2.0.3
+      diff: 5.1.0
+      kleur: 4.1.5
+      sade: 1.8.1
+    dev: false
+
+  /vfile-message@3.1.4:
+    resolution: {integrity: sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==}
+    dependencies:
+      '@types/unist': 2.0.7
+      unist-util-stringify-position: 3.0.3
+    dev: false
+
+  /vfile@5.3.7:
+    resolution: {integrity: sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==}
+    dependencies:
+      '@types/unist': 2.0.7
+      is-buffer: 2.0.5
+      unist-util-stringify-position: 3.0.3
+      vfile-message: 3.1.4
+    dev: false
 
   /viem@1.5.0(typescript@5.0.4):
     resolution: {integrity: sha512-+SVCVaXJRR+fE9q6Sf6q9droB6TunPGY1JfwB3uTdxwWrkgr3qq/NbXaRdtEk+TyaOEjzZQr7t6vUzjOL0zL0Q==}

--- a/src/chains/arbitrum/signatureTypes.ts
+++ b/src/chains/arbitrum/signatureTypes.ts
@@ -1,7 +1,8 @@
 import { signatureTypes as mainnetSignatureTypes } from '@/chains/mainnet/signatureTypes';
 import { SignatureType } from '@/types';
 
-const txTypeDocs = 'https://developer.arbitrum.io/arbos/geth#transaction-types';
+const txTypeDocs =
+  '[Arbitrum Transaction Types](https://developer.arbitrum.io/arbos/geth#transaction-types)';
 
 const arbitrumDepositTx: SignatureType = {
   prefixByte: 0x64,

--- a/src/chains/arbitrum/signatureTypes.ts
+++ b/src/chains/arbitrum/signatureTypes.ts
@@ -8,7 +8,7 @@ const arbitrumDepositTx: SignatureType = {
   prefixByte: 0x64,
   description:
     "Represents a user deposit from L1 to L2. This increases the user's balance by the amount deposited on L1.",
-  signedData: ['keccak256(0x64 || rlp([chainId, l1RequestId, from, to, value]))'],
+  signedData: ['`keccak256(0x64 || rlp([chainId, l1RequestId, from, to, value]))`'],
   signs: 'transaction',
   references: [
     txTypeDocs,
@@ -22,7 +22,7 @@ const arbitrumUnsignedTx: SignatureType = {
   description:
     "A message from a user on L1 to a contract on L2 that uses the bridge for authentication instead of requiring the user's signature.",
   signedData: [
-    'keccak256(0x65 || rlp([chainId, from, nonce, maxFeePerGas, gasLimit, to, value, data]))',
+    '`keccak256(0x65 || rlp([chainId, from, nonce, maxFeePerGas, gasLimit, to, value, data]))`',
   ],
   signs: 'transaction',
   references: [
@@ -37,7 +37,7 @@ const arbitrumContractTx: SignatureType = {
   description:
     "Similar to an `ArbitrumUnsignedTx` but intended for smart contracts. Uses the bridge's unique, sequential nonce rather than requiring the caller specify their own.",
   signedData: [
-    'keccak256(0x66 || rlp([chainId, requestId, from, maxFeePerGas, gasLimit, to, value, data]))',
+    '`keccak256(0x66 || rlp([chainId, requestId, from, maxFeePerGas, gasLimit, to, value, data]))`',
   ],
   signs: 'transaction',
   references: [
@@ -51,7 +51,7 @@ const arbitrumSubmitRetryableTx: SignatureType = {
   prefixByte: 0x69,
   description: 'A retryable submission and may schedule an ArbitrumRetryTx if provided enough gas.',
   signedData: [
-    'keccak256(0x69 || rlp([chainId, requestId, from, l1BaseFee, depositValue, maxFeePerGas, gasLimit, retryTo, retryValue, beneficiary, maxSubmissionFee, feeRefundAddress, retryData]))',
+    '`keccak256(0x69 || rlp([chainId, requestId, from, l1BaseFee, depositValue, maxFeePerGas, gasLimit, retryTo, retryValue, beneficiary, maxSubmissionFee, feeRefundAddress, retryData]))`',
   ],
   signs: 'transaction',
   references: [
@@ -66,7 +66,7 @@ const arbitrumRetryTx: SignatureType = {
   description:
     'Transactions scheduled by calls to the redeem precompile method and via retryable auto-redemption.',
   signedData: [
-    'keccak256(0x68 || rlp([chainId, nonce, from, maxFeePerGas, gasLimit, to, value, data, ticketId, refundTo, maxRefund, submissionFeeRefund]))',
+    '`keccak256(0x68 || rlp([chainId, nonce, from, maxFeePerGas, gasLimit, to, value, data, ticketId, refundTo, maxRefund, submissionFeeRefund]))`',
   ],
   signs: 'transaction',
   references: [
@@ -79,7 +79,7 @@ const arbitrumRetryTx: SignatureType = {
 const arbitrumInternalTx: SignatureType = {
   prefixByte: 0x6a,
   description: 'ArbOS-created transaction to update state between user-generated transactions.',
-  signedData: ['keccak256(0x6a || rlp([chainId, data]))'],
+  signedData: ['`keccak256(0x6a || rlp([chainId, data]))`'],
   signs: 'transaction',
   references: [
     txTypeDocs,

--- a/src/chains/arbitrum/vm/opcodes/block/blockhash.ts
+++ b/src/chains/arbitrum/vm/opcodes/block/blockhash.ts
@@ -20,9 +20,6 @@ export const blockhash: Omit<Opcode, 'supportedHardforks'> = {
     },
   ],
   references: [
-    {
-      name: 'Differences between Arbitrum and Ethereum opcodes',
-      url: 'https://developer.arbitrum.io/solidity-support',
-    },
+    '[Arbitrum Differences from Solidity on Ethereum](https://developer.arbitrum.io/solidity-support)',
   ],
 };

--- a/src/chains/arbitrum/vm/opcodes/block/coinbase.ts
+++ b/src/chains/arbitrum/vm/opcodes/block/coinbase.ts
@@ -18,9 +18,6 @@ export const coinbase: Omit<Opcode, 'supportedHardforks'> = {
     },
   ],
   references: [
-    {
-      name: 'Differences between Arbitrum and Ethereum opcodes',
-      url: 'https://developer.arbitrum.io/solidity-support',
-    },
+    '[Arbitrum Differences from Solidity on Ethereum](https://developer.arbitrum.io/solidity-support)',
   ],
 };

--- a/src/chains/arbitrum/vm/opcodes/block/number.ts
+++ b/src/chains/arbitrum/vm/opcodes/block/number.ts
@@ -14,13 +14,7 @@ export const number: Omit<Opcode, 'supportedHardforks'> = {
     },
   ],
   references: [
-    {
-      name: 'Differences between Arbitrum and Ethereum',
-      url: 'https://developer.arbitrum.io/solidity-support',
-    },
-    {
-      name: 'Arbitrum Block Numbers and Time',
-      url: 'https://developer.arbitrum.io/time',
-    },
+    '[Arbitrum Differences from Solidity on Ethereum](https://developer.arbitrum.io/solidity-support)',
+    '[Arbitrum Block Numbers and Time](https://developer.arbitrum.io/time)',
   ],
 };

--- a/src/chains/arbitrum/vm/opcodes/block/prevrandao.ts
+++ b/src/chains/arbitrum/vm/opcodes/block/prevrandao.ts
@@ -8,9 +8,6 @@ export const prevrandao: Omit<Opcode, 'supportedHardforks'> = {
   examples: [{ output: '1' }],
   description: 'Returns the constant `1`.',
   references: [
-    {
-      name: 'Differences between Arbitrum and Ethereum opcodes',
-      url: 'https://developer.arbitrum.io/solidity-support',
-    },
+    '[Arbitrum Differences from Solidity on Ethereum](https://developer.arbitrum.io/solidity-support)',
   ],
 };

--- a/src/chains/arbitrum/vm/opcodes/environment/caller.ts
+++ b/src/chains/arbitrum/vm/opcodes/environment/caller.ts
@@ -5,13 +5,7 @@ const { references: _references, ...opcode } = baseOpcode;
 export const caller: Omit<Opcode, 'supportedHardforks'> = {
   ...opcode,
   references: [
-    {
-      name: 'Differences between Arbitrum and Ethereum',
-      url: 'https://developer.arbitrum.io/solidity-support',
-    },
-    {
-      name: 'Retryable ticket address aliasing',
-      url: 'https://developer.arbitrum.io/arbos/l1-to-l2-messaging#address-aliasing',
-    },
+    '[Arbitrum Differences from Solidity on Ethereum](https://developer.arbitrum.io/solidity-support)',
+    '[L1 to L2 Messaging, Address Aliasing](https://developer.arbitrum.io/arbos/l1-to-l2-messaging#address-aliasing)',
   ],
 };

--- a/src/chains/arbitrum/vm/opcodes/environment/origin.ts
+++ b/src/chains/arbitrum/vm/opcodes/environment/origin.ts
@@ -5,13 +5,7 @@ const { references: _references, ...opcode } = baseOpcode;
 export const origin: Omit<Opcode, 'supportedHardforks'> = {
   ...opcode,
   references: [
-    {
-      name: 'Differences between Arbitrum and Ethereum',
-      url: 'https://developer.arbitrum.io/solidity-support',
-    },
-    {
-      name: 'Retryable ticket address aliasing',
-      url: 'https://developer.arbitrum.io/arbos/l1-to-l2-messaging#address-aliasing',
-    },
+    '[Arbitrum Differences from Solidity on Ethereum](https://developer.arbitrum.io/solidity-support)',
+    '[L1 to L2 Messaging, Address Aliasing](https://developer.arbitrum.io/arbos/l1-to-l2-messaging#address-aliasing)',
   ],
 };

--- a/src/chains/arbitrum/vm/opcodes/stack/push0.ts
+++ b/src/chains/arbitrum/vm/opcodes/stack/push0.ts
@@ -5,9 +5,6 @@ const { references: _references, ...opcode } = baseOpcode;
 export const push0: Omit<Opcode, 'supportedHardforks'> = {
   ...opcode,
   references: [
-    {
-      name: 'Differences between Arbitrum and Ethereum opcodes',
-      url: 'https://developer.arbitrum.io/solidity-support',
-    },
+    '[Arbitrum Differences from Solidity on Ethereum](https://developer.arbitrum.io/solidity-support)',
   ],
 };

--- a/src/chains/arbitrum/vm/precompiles.ts
+++ b/src/chains/arbitrum/vm/precompiles.ts
@@ -1,7 +1,9 @@
 import { precompiles as mainnetPrecompiles } from '@/chains/mainnet/vm/precompiles';
 import { Precompile } from '@/types';
 
-// https://developer.arbitrum.io/for-devs/useful-addresses#precompiles
+const ARBITRUM_SMART_CONTRACT_ADDRESSES =
+  '[Arbitrum Smart Contract Addresses](https://developer.arbitrum.io/for-devs/useful-addresses)';
+
 export const precompiles: Precompile[] = [
   ...mainnetPrecompiles,
   {
@@ -27,7 +29,7 @@ export const precompiles: Precompile[] = [
       'function withdrawEth(address destination) payable returns (uint256)',
     ],
     deprecated: false,
-    references: ['https://developer.arbitrum.io/for-devs/useful-addresses'],
+    references: [ARBITRUM_SMART_CONTRACT_ADDRESSES],
   },
   {
     address: '0x000000000000000000000000000000000000006E',
@@ -51,7 +53,7 @@ export const precompiles: Precompile[] = [
       'function submitRetryable(bytes32 requestId, uint256 l1BaseFee, uint256 deposit, uint256 callvalue, uint256 gasFeeCap, uint64 gasLimit, uint256 maxSubmissionFee, address feeRefundAddress, address beneficiary, address retryTo, bytes retryData)',
     ],
     deprecated: false,
-    references: ['https://developer.arbitrum.io/for-devs/useful-addresses'],
+    references: [ARBITRUM_SMART_CONTRACT_ADDRESSES],
   },
   {
     address: '0x000000000000000000000000000000000000006C',
@@ -77,7 +79,7 @@ export const precompiles: Precompile[] = [
       'function getPricingInertia() view returns (uint64)',
     ],
     deprecated: false,
-    references: ['https://developer.arbitrum.io/for-devs/useful-addresses'],
+    references: [ARBITRUM_SMART_CONTRACT_ADDRESSES],
   },
   {
     address: '0x0000000000000000000000000000000000000066',
@@ -94,7 +96,7 @@ export const precompiles: Precompile[] = [
       'function size() view returns (uint256)',
     ],
     deprecated: false,
-    references: ['https://developer.arbitrum.io/for-devs/useful-addresses'],
+    references: [ARBITRUM_SMART_CONTRACT_ADDRESSES],
   },
   {
     address: '0x000000000000000000000000000000000000006F',
@@ -105,7 +107,7 @@ export const precompiles: Precompile[] = [
       'function getStats() view returns (uint256, uint256, uint256, uint256, uint256, uint256)',
     ],
     deprecated: false,
-    references: ['https://developer.arbitrum.io/for-devs/useful-addresses'],
+    references: [ARBITRUM_SMART_CONTRACT_ADDRESSES],
   },
   {
     address: '0x00000000000000000000000000000000000000C8',
@@ -123,7 +125,7 @@ export const precompiles: Precompile[] = [
       'function nitroGenesisBlock() pure returns (uint256 number)',
     ],
     deprecated: false,
-    references: ['https://developer.arbitrum.io/for-devs/useful-addresses'],
+    references: [ARBITRUM_SMART_CONTRACT_ADDRESSES],
   },
   {
     address: '0x0000000000000000000000000000000000000067',
@@ -131,7 +133,7 @@ export const precompiles: Precompile[] = [
     description: 'Provides a registry of BLS public keys for accounts.',
     logicAbi: [], // TODO have not found ABI yet.
     deprecated: false,
-    references: ['https://developer.arbitrum.io/for-devs/useful-addresses'],
+    references: [ARBITRUM_SMART_CONTRACT_ADDRESSES],
   },
   {
     address: '0x0000000000000000000000000000000000000070',
@@ -167,7 +169,7 @@ export const precompiles: Precompile[] = [
     ],
     deprecated: false,
     references: [
-      'https://developer.arbitrum.io/for-devs/useful-addresses',
+      ARBITRUM_SMART_CONTRACT_ADDRESSES,
       'https://github.com/OffchainLabs/nitro/blob/c041e98e089ca91f007a71cd56535c38f7cf4e85/precompiles/ArbOwner.go',
     ],
   },
@@ -184,7 +186,7 @@ export const precompiles: Precompile[] = [
     ],
     deprecated: false,
     references: [
-      'https://developer.arbitrum.io/for-devs/useful-addresses',
+      ARBITRUM_SMART_CONTRACT_ADDRESSES,
       'https://github.com/OffchainLabs/nitro/blob/c041e98e089ca91f007a71cd56535c38f7cf4e85/precompiles/ArbOwnerPublic.go',
     ],
   },
@@ -204,7 +206,7 @@ export const precompiles: Precompile[] = [
       'function setTxBaseFee(address aggregator, uint256 feeInL1Gas)',
     ],
     deprecated: false,
-    references: ['https://developer.arbitrum.io/for-devs/useful-addresses'],
+    references: [ARBITRUM_SMART_CONTRACT_ADDRESSES],
   },
   {
     address: '0x0000000000000000000000000000000000000068',
@@ -217,6 +219,6 @@ export const precompiles: Precompile[] = [
       'function upload(bytes buf)',
     ],
     deprecated: false,
-    references: ['https://developer.arbitrum.io/for-devs/useful-addresses'],
+    references: [ARBITRUM_SMART_CONTRACT_ADDRESSES],
   },
 ];

--- a/src/chains/arbitrum/vm/precompiles.ts
+++ b/src/chains/arbitrum/vm/precompiles.ts
@@ -8,7 +8,7 @@ export const precompiles: Precompile[] = [
   ...mainnetPrecompiles,
   {
     address: '0x0000000000000000000000000000000000000064',
-    name: 'ArbSys',
+    name: '`ArbSys`',
     description:
       'Exposes a variety of system-level functionality for interacting with Ethereum and understanding the call stack.',
     logicAbi: [
@@ -33,7 +33,7 @@ export const precompiles: Precompile[] = [
   },
   {
     address: '0x000000000000000000000000000000000000006E',
-    name: 'ArbRetryableTx',
+    name: '`ArbRetryableTx`',
     description: 'Manages retryable transactions related to data retrieval and interactions.',
     logicAbi: [
       'error NoTicketWithID()',
@@ -57,7 +57,7 @@ export const precompiles: Precompile[] = [
   },
   {
     address: '0x000000000000000000000000000000000000006C',
-    name: 'ArbGasInfo',
+    name: '`ArbGasInfo`',
     description: 'Provides insight into the costs of using Arbitrum.',
     logicAbi: [
       'function getAmortizedCostCapBips() view returns (uint64)',
@@ -83,7 +83,7 @@ export const precompiles: Precompile[] = [
   },
   {
     address: '0x0000000000000000000000000000000000000066',
-    name: 'ArbAddressTable',
+    name: '`ArbAddressTable`',
     description:
       'Allows registering and retrieving commonly used addresses via indices, saving calldata.',
     logicAbi: [
@@ -100,7 +100,7 @@ export const precompiles: Precompile[] = [
   },
   {
     address: '0x000000000000000000000000000000000000006F',
-    name: 'ArbStatistics',
+    name: '`ArbStatistics`',
     description:
       'Provides statistics about Arbitrum, such as the number of blocks, accounts, transactions, and contracts.',
     logicAbi: [
@@ -111,7 +111,7 @@ export const precompiles: Precompile[] = [
   },
   {
     address: '0x00000000000000000000000000000000000000C8',
-    name: 'NodeInterface',
+    name: '`NodeInterface`',
     description:
       'Retrieves the revenant data of calls by Arbitrum contracts to execute them in Ethereum via the Outbox contract.',
     logicAbi: [
@@ -129,7 +129,7 @@ export const precompiles: Precompile[] = [
   },
   {
     address: '0x0000000000000000000000000000000000000067',
-    name: 'ArbBLS',
+    name: '`ArbBLS`',
     description: 'Provides a registry of BLS public keys for accounts.',
     logicAbi: [], // TODO have not found ABI yet.
     deprecated: false,
@@ -137,7 +137,7 @@ export const precompiles: Precompile[] = [
   },
   {
     address: '0x0000000000000000000000000000000000000070',
-    name: 'ArbOwner',
+    name: '`ArbOwner`',
     description:
       'Provides owners with tools for managing the rollup. All calls to this precompile are authorized by the OwnerPrecompile wrapper, which ensures only a chain owner can access these methods.',
     logicAbi: [
@@ -175,7 +175,7 @@ export const precompiles: Precompile[] = [
   },
   {
     address: '0x000000000000000000000000000000000000006b',
-    name: 'ArbOwnerPublic',
+    name: '`ArbOwnerPublic`',
     description:
       'Provides non-owners with info about the current chain owners. The calls to this precompile do not require the sender be a chain owner. For those that are, see `ArbOwner`.',
     logicAbi: [
@@ -192,7 +192,7 @@ export const precompiles: Precompile[] = [
   },
   {
     address: '0x000000000000000000000000000000000000006D',
-    name: 'ArbAggregator',
+    name: '`ArbAggregator`',
     description:
       "Provides aggregators and their users methods for configuring how they participate in Ethereum aggregation. The default aggregator is Arbitrum's Sequencer.",
     logicAbi: [
@@ -210,7 +210,7 @@ export const precompiles: Precompile[] = [
   },
   {
     address: '0x0000000000000000000000000000000000000068',
-    name: 'ArbFunctionTable',
+    name: '`ArbFunctionTable`',
     description:
       'Allows aggregators to manage function tables for one form of transaction compression.',
     logicAbi: [

--- a/src/chains/arbitrum/vm/predeploys.ts
+++ b/src/chains/arbitrum/vm/predeploys.ts
@@ -6,7 +6,7 @@ const ARBITRUM_SMART_CONTRACT_ADDRESSES =
 export const predeploys: Predeploy[] = [
   {
     address: '0x5288c571Fd7aD117beA99bF60FE0846C4E84F933',
-    name: 'L2 Gateway Router',
+    name: '`L2GatewayRouter`',
     description:
       'Handles withdrawals from Ethereum into Arbitrum. Tokens are routed to their appropriate L2 gateway (Router itself also conforms to the Gateway interface).',
     proxyAbi: [
@@ -47,7 +47,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x09e9222E96E7B4AE2a407B98d48e330053351EEe',
-    name: 'L2 ERC20 Gateway',
+    name: '`L2ERC20Gateway`',
     description:
       "Initiates Arbitrum to Ethereum ERC20 transfers, which are forwarded to the token's L2 Gateway to communicate with its corresponding L1 Gateway.",
     proxyAbi: [
@@ -86,7 +86,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x096760F208390250649E3e8763348E783AEF5562',
-    name: 'L2 Arb-Custom Gateway',
+    name: '`L2CustomGateway`',
     description:
       'Allows to transfer of custom tokens from Arbitrum to Ethereum, which are forwarded to the L2 Gateway to communicate with its corresponding L1 Gateway.',
     proxyAbi: [
@@ -125,7 +125,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x6c411aD3E74De3E7Bd422b94A27770f5B86C623B',
-    name: 'L2 Weth Gateway',
+    name: '`L2WethGateway`',
     description:
       "Handles Arbitrum to Ethereum transfers of WETH by unwrapping the Ether and re-wrapping it on Ethereum, ensuring that all WETH tokens are always fully collateralized on the layer it's transferred to.",
     proxyAbi: [
@@ -164,7 +164,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
-    name: 'L2 Weth',
+    name: 'L2Weth',
     description:
       'Wrapped Ether contract on Arbitrum, which is an ERC-20 token that represents 1 Ether.',
     proxyAbi: [
@@ -215,7 +215,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0xd570aCE65C43af47101fC6250FD6fC63D1c22a86',
-    name: 'L2 Proxy Admin',
+    name: 'ProxyAdmin',
     description: 'The owner of all of the Arbitrum proxy contracts set at the predeploys.',
     logicAbi: [
       'event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)',
@@ -234,7 +234,7 @@ export const predeploys: Predeploy[] = [
 
   {
     address: '0x0000000000000000000000000000000000000065',
-    name: 'ArbInfo',
+    name: '`ArbInfo`',
     description: 'Provides the ability to lookup basic info about accounts and contracts.',
     logicAbi: [
       'function getBalance(address account) view returns (uint256)',

--- a/src/chains/arbitrum/vm/predeploys.ts
+++ b/src/chains/arbitrum/vm/predeploys.ts
@@ -1,6 +1,8 @@
 import { Predeploy } from '@/types';
 
-// https://developer.arbitrum.io/useful-addresses#arbitrum-precompiles-l2-same-on-all-arb-chains
+const ARBITRUM_SMART_CONTRACT_ADDRESSES =
+  '[Arbitrum Smart Contract Addresses](https://developer.arbitrum.io/for-devs/useful-addresses)';
+
 export const predeploys: Predeploy[] = [
   {
     address: '0x5288c571Fd7aD117beA99bF60FE0846C4E84F933',
@@ -41,7 +43,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0xe80eb0238029333e368e0bDDB7acDf1b9cb28278',
     deprecated: false,
-    references: ['https://developer.arbitrum.io/for-devs/useful-addresses'],
+    references: [ARBITRUM_SMART_CONTRACT_ADDRESSES],
   },
   {
     address: '0x09e9222E96E7B4AE2a407B98d48e330053351EEe',
@@ -80,7 +82,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0x1DCf7D03574fbC7C205F41f2e116eE094a652e93',
     deprecated: false,
-    references: ['https://developer.arbitrum.io/for-devs/useful-addresses'],
+    references: [ARBITRUM_SMART_CONTRACT_ADDRESSES],
   },
   {
     address: '0x096760F208390250649E3e8763348E783AEF5562',
@@ -119,7 +121,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0x190274fEa8f30e3f48CE43aDCBd9a74110118284',
     deprecated: false,
-    references: ['https://developer.arbitrum.io/for-devs/useful-addresses'],
+    references: [ARBITRUM_SMART_CONTRACT_ADDRESSES],
   },
   {
     address: '0x6c411aD3E74De3E7Bd422b94A27770f5B86C623B',
@@ -158,7 +160,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0x806421D09cDb253aa9d128a658e60c0B95eFFA01',
     deprecated: false,
-    references: ['https://developer.arbitrum.io/for-devs/useful-addresses'],
+    references: [ARBITRUM_SMART_CONTRACT_ADDRESSES],
   },
   {
     address: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
@@ -209,7 +211,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0x8b194bEae1d3e0788A1a35173978001ACDFba668',
     deprecated: false,
-    references: ['https://developer.arbitrum.io/for-devs/useful-addresses'],
+    references: [ARBITRUM_SMART_CONTRACT_ADDRESSES],
   },
   {
     address: '0xd570aCE65C43af47101fC6250FD6fC63D1c22a86',
@@ -227,7 +229,7 @@ export const predeploys: Predeploy[] = [
       'function upgradeAndCall(address proxy, address implementation, bytes data) payable',
     ],
     deprecated: false,
-    references: ['https://developer.arbitrum.io/for-devs/useful-addresses'],
+    references: [ARBITRUM_SMART_CONTRACT_ADDRESSES],
   },
 
   {
@@ -239,6 +241,6 @@ export const predeploys: Predeploy[] = [
       'function getCode(address account) view returns (bytes)',
     ],
     deprecated: false,
-    references: ['https://developer.arbitrum.io/for-devs/useful-addresses'],
+    references: [ARBITRUM_SMART_CONTRACT_ADDRESSES],
   },
 ];

--- a/src/chains/mainnet/signatureTypes.ts
+++ b/src/chains/mainnet/signatureTypes.ts
@@ -19,8 +19,8 @@ export const validSigTypes: SignatureType[] = [
     prefixByte: 0x0,
     description: 'Legacy (untyped) transaction',
     signedData: [
-      'keccak256(rlp([nonce, gasPrice, gasLimit, to, value, data]))',
-      'keccak256(rlp([nonce, gasPrice, gasLimit, to, value, data, chainId, 0, 0]))',
+      '`keccak256(rlp([nonce, gasPrice, gasLimit, to, value, data]))`',
+      '`keccak256(rlp([nonce, gasPrice, gasLimit, to, value, data, chainId, 0, 0]))`',
     ],
     signs: 'transaction',
     references: ['https://eips.ethereum.org/EIPS/eip-155', eip2718, sigTypes],
@@ -32,7 +32,7 @@ export const validSigTypes: SignatureType[] = [
     prefixByte: 0x1,
     description: 'EIP-2930 Access list transaction',
     signedData: [
-      'keccak256(0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList]))',
+      '`keccak256(0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList]))`',
     ],
     signs: 'transaction',
     references: ['https://eips.ethereum.org/EIPS/eip-2930', eip2718, sigTypes],
@@ -41,7 +41,7 @@ export const validSigTypes: SignatureType[] = [
     prefixByte: 0x2,
     description: 'EIP-1559 transaction',
     signedData: [
-      'keccak256(0x02 || rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList]))',
+      '`keccak256(0x02 || rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList]))`',
     ],
     signs: 'transaction',
     references: ['https://eips.ethereum.org/EIPS/eip-1559', eip2718, sigTypes],
@@ -49,7 +49,7 @@ export const validSigTypes: SignatureType[] = [
   {
     prefixByte: 0x3,
     description: 'Unused, but tentatively reserved for EIP-3074',
-    signedData: ['keccak256(0x03 || chainId || paddedInvokerAddress || commit)'],
+    signedData: ['`keccak256(0x03 || chainId || paddedInvokerAddress || commit)`'],
     signs: 'transaction',
     references: ['https://eips.ethereum.org/EIPS/eip-3074', eip2718, sigTypes],
   },
@@ -57,7 +57,7 @@ export const validSigTypes: SignatureType[] = [
     prefixByte: 0x19,
     description:
       'Used for signatures of data payloads to prevent collisions between data signatures and transaction signatures',
-    signedData: ['keccak256(0x19 || 1-byte-version || versionSpecificData || dataToSign)'],
+    signedData: ['`keccak256(0x19 || 1-byte-version || versionSpecificData || dataToSign)`'],
     signs: 'data',
     references: ['https://eips.ethereum.org/EIPS/eip-191', sigTypes],
   },

--- a/src/chains/mainnet/vm/opcodes/arithmetic/add.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/add.ts
@@ -43,14 +43,8 @@ export const add: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x01),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 30),
-    },
+    evmCodesOpcodesLink(0x01),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 30),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/arithmetic/addmod.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/addmod.ts
@@ -49,14 +49,8 @@ export const addmod: Opcode = {
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   notes: ['All intermediate calculations of this operation are not subject to the 2**256 modulo'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x08),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 234),
-    },
+    evmCodesOpcodesLink(0x08),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 234),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/arithmetic/div.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/div.ts
@@ -44,14 +44,8 @@ export const div: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x04),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 111),
-    },
+    evmCodesOpcodesLink(0x04),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 111),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/arithmetic/exp.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/exp.ts
@@ -58,14 +58,8 @@ export const exp: Opcode = {
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   notes: ['All intermediate calculations of this operation are not subject to the 2**256 modulo'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x0a),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 296),
-    },
+    evmCodesOpcodesLink(0x0a),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 296),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/arithmetic/mod.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/mod.ts
@@ -44,14 +44,8 @@ export const mod: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x06),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 174),
-    },
+    evmCodesOpcodesLink(0x06),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 174),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/arithmetic/mul.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/mul.ts
@@ -43,14 +43,8 @@ export const mul: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x02),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 84),
-    },
+    evmCodesOpcodesLink(0x02),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 84),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/arithmetic/mulmod.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/mulmod.ts
@@ -53,14 +53,8 @@ export const mulmod: Opcode = {
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   notes: ['All intermediate calculations of this operation are not subject to the 2**256 modulo'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x08),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 265),
-    },
+    evmCodesOpcodesLink(0x08),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 265),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/arithmetic/sdiv.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/sdiv.ts
@@ -50,14 +50,8 @@ export const sdiv: Opcode = {
     'All values are treated as two’s complement signed 256-bit integers. Note the overflow semantic when −2**255 is negated.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x05),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 141),
-    },
+    evmCodesOpcodesLink(0x05),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 141),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/arithmetic/signextend.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/signextend.ts
@@ -43,14 +43,8 @@ export const signextend: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x0b),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 329),
-    },
+    evmCodesOpcodesLink(0x0b),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 329),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/arithmetic/smod.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/smod.ts
@@ -50,14 +50,8 @@ export const smod: Opcode = {
     'All values are treated as two’s complement signed 256-bit integers. Note the overflow semantic when −2**255 is negated.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x07),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 174),
-    },
+    evmCodesOpcodesLink(0x07),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 174),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/arithmetic/sub.ts
+++ b/src/chains/mainnet/vm/opcodes/arithmetic/sub.ts
@@ -43,14 +43,8 @@ export const sub: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x03),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 57),
-    },
+    evmCodesOpcodesLink(0x03),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 57),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/bitwise/and.ts
+++ b/src/chains/mainnet/vm/opcodes/bitwise/and.ts
@@ -43,14 +43,8 @@ export const and: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x16),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Bitwise, 22),
-    },
+    evmCodesOpcodesLink(0x16),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Bitwise, 22),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/bitwise/byte.ts
+++ b/src/chains/mainnet/vm/opcodes/bitwise/byte.ts
@@ -44,14 +44,8 @@ export const byte: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x1a),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Bitwise, 121),
-    },
+    evmCodesOpcodesLink(0x1a),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Bitwise, 121),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/bitwise/not.ts
+++ b/src/chains/mainnet/vm/opcodes/bitwise/not.ts
@@ -33,14 +33,8 @@ export const not: Opcode = {
   playgroundLink: evmCodesPlaygroundLink('%27PUSH1%200%5CnNOT%27_'),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x19),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Bitwise, 97),
-    },
+    evmCodesOpcodesLink(0x19),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Bitwise, 97),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/bitwise/or.ts
+++ b/src/chains/mainnet/vm/opcodes/bitwise/or.ts
@@ -43,14 +43,8 @@ export const or: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x17),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Bitwise, 47),
-    },
+    evmCodesOpcodesLink(0x17),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Bitwise, 47),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/bitwise/sar.ts
+++ b/src/chains/mainnet/vm/opcodes/bitwise/sar.ts
@@ -46,14 +46,8 @@ export const sar: Opcode = {
     'Shift the bits towards the least significant one. The bits moved before the first one are discarded, the new bits are set to 0 if the previous most significant bit was 0, otherwise the new bits are set to 1.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x1d),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Bitwise, 213),
-    },
+    evmCodesOpcodesLink(0x1d),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Bitwise, 213),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Constantinople),
 };

--- a/src/chains/mainnet/vm/opcodes/bitwise/shl.ts
+++ b/src/chains/mainnet/vm/opcodes/bitwise/shl.ts
@@ -46,14 +46,8 @@ export const shl: Opcode = {
     'Shift the bits towards the least significant one. The bits moved before the first one are discarded, the new bits are set to 0.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x1b),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Bitwise, 157),
-    },
+    evmCodesOpcodesLink(0x1b),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Bitwise, 157),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Constantinople),
 };

--- a/src/chains/mainnet/vm/opcodes/bitwise/shr.ts
+++ b/src/chains/mainnet/vm/opcodes/bitwise/shr.ts
@@ -46,14 +46,8 @@ export const shr: Opcode = {
     'Shift the bits towards the least significant one. The bits moved before the first one are discarded, the new bits are set to 0.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x1c),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Bitwise, 185),
-    },
+    evmCodesOpcodesLink(0x1c),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Bitwise, 185),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Constantinople),
 };

--- a/src/chains/mainnet/vm/opcodes/bitwise/xor.ts
+++ b/src/chains/mainnet/vm/opcodes/bitwise/xor.ts
@@ -43,14 +43,8 @@ export const xor: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x18),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Bitwise, 72),
-    },
+    evmCodesOpcodesLink(0x18),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Bitwise, 72),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/block/blockhash.ts
+++ b/src/chains/mainnet/vm/opcodes/block/blockhash.ts
@@ -29,14 +29,8 @@ export const blockhash: Opcode = {
   ],
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x40),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Block, 22),
-    },
+    evmCodesOpcodesLink(0x40),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Block, 22),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/block/chainid.ts
+++ b/src/chains/mainnet/vm/opcodes/block/chainid.ts
@@ -26,14 +26,8 @@ export const chainid: Opcode = {
   playgroundLink: evmCodesPlaygroundLink('%27CHAINID%27_'),
   errorCases: ['Not enough gas', 'Stack overflow'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x46),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Block, 222),
-    },
+    evmCodesOpcodesLink(0x46),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Block, 222),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Istanbul),
 };

--- a/src/chains/mainnet/vm/opcodes/block/coinbase.ts
+++ b/src/chains/mainnet/vm/opcodes/block/coinbase.ts
@@ -20,14 +20,8 @@ export const coinbase: Opcode = {
   ],
   errorCases: ['Not enough gas.', 'Stack overflow.'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x41),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Block, 60),
-    },
+    evmCodesOpcodesLink(0x41),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Block, 60),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/block/gaslimit.ts
+++ b/src/chains/mainnet/vm/opcodes/block/gaslimit.ts
@@ -20,14 +20,8 @@ export const gaslimit: Opcode = {
   ],
   errorCases: ['Not enough gas', 'Stack overflow'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x45),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Block, 190),
-    },
+    evmCodesOpcodesLink(0x45),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Block, 190),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/block/number.ts
+++ b/src/chains/mainnet/vm/opcodes/block/number.ts
@@ -20,14 +20,8 @@ export const number: Opcode = {
   ],
   errorCases: ['Not enough gas', 'Stack overflow'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x43),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Block, 126),
-    },
+    evmCodesOpcodesLink(0x43),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Block, 126),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/block/prevrandao.ts
+++ b/src/chains/mainnet/vm/opcodes/block/prevrandao.ts
@@ -25,18 +25,9 @@ export const prevrandao: Opcode = {
   // TODO: add the evm.codes playground link once available
   errorCases: ['Not enough gas.', 'Stack overflow.'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x44),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Block, 158),
-    },
-    {
-      name: 'EIP-4399: Supplant DIFFICULTY opcode with PREVRANDAO',
-      url: 'https://eips.ethereum.org/EIPS/eip-4399',
-    },
+    evmCodesOpcodesLink(0x44),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Block, 158),
+    'https://eips.ethereum.org/EIPS/eip-4399',
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/block/timestamp.ts
+++ b/src/chains/mainnet/vm/opcodes/block/timestamp.ts
@@ -20,14 +20,8 @@ export const timestamp: Opcode = {
   ],
   errorCases: ['Not enough gas', 'Stack overflow'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x42),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Block, 93),
-    },
+    evmCodesOpcodesLink(0x42),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Block, 93),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/comparison/eq.ts
+++ b/src/chains/mainnet/vm/opcodes/comparison/eq.ts
@@ -44,14 +44,8 @@ export const eq: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x14),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Comparison, 128),
-    },
+    evmCodesOpcodesLink(0x14),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Comparison, 128),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/comparison/gt.ts
+++ b/src/chains/mainnet/vm/opcodes/comparison/gt.ts
@@ -44,14 +44,8 @@ export const gt: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x11),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Comparison, 75),
-    },
+    evmCodesOpcodesLink(0x11),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Comparison, 75),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/comparison/iszero.ts
+++ b/src/chains/mainnet/vm/opcodes/comparison/iszero.ts
@@ -40,14 +40,8 @@ export const iszero: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x15),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Comparison, 155),
-    },
+    evmCodesOpcodesLink(0x15),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Comparison, 155),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/comparison/lt.ts
+++ b/src/chains/mainnet/vm/opcodes/comparison/lt.ts
@@ -44,14 +44,8 @@ export const lt: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x10),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Comparison, 22),
-    },
+    evmCodesOpcodesLink(0x10),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Comparison, 22),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/comparison/sgt.ts
+++ b/src/chains/mainnet/vm/opcodes/comparison/sgt.ts
@@ -44,14 +44,8 @@ export const sgt: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x13),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Comparison, 102),
-    },
+    evmCodesOpcodesLink(0x13),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Comparison, 102),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/comparison/slt.ts
+++ b/src/chains/mainnet/vm/opcodes/comparison/slt.ts
@@ -45,14 +45,8 @@ export const slt: Opcode = {
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   notes: ['All values are treated as two’s complement signed 256-bit integers.'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x12),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Comparison, 49),
-    },
+    evmCodesOpcodesLink(0x12),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Comparison, 49),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/controlFlow/gas.ts
+++ b/src/chains/mainnet/vm/opcodes/controlFlow/gas.ts
@@ -24,14 +24,8 @@ export const gas: Omit<Opcode, 'examples'> = {
   ),
   errorCases: ['Not enough gas', 'Stack overflow'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x5a),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 125),
-    },
+    evmCodesOpcodesLink(0x5a),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 125),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/controlFlow/jump.ts
+++ b/src/chains/mainnet/vm/opcodes/controlFlow/jump.ts
@@ -31,14 +31,8 @@ export const jump: Omit<Opcode, 'examples'> = {
     'The program counter (PC) is a byte offset in the deployed code. It indicates which instruction will be executed next. When an ADD is executed, for example, the PC is incremented by 1, since the instruction is 1 byte. The PUSH instructions are bigger than one byte, and so will increment the counter accordingly. The JUMP instruction alters the program counter, thus breaking the linear path of the execution to another point in the deployed code. It is used to implement functionalities like functions.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x56),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 45),
-    },
+    evmCodesOpcodesLink(0x56),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 45),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/controlFlow/jumpdest.ts
+++ b/src/chains/mainnet/vm/opcodes/controlFlow/jumpdest.ts
@@ -11,14 +11,8 @@ export const jumpdest: Omit<Opcode, 'examples' | 'errorCases'> = {
     'Mark a valid destination for JUMP or JUMPI. This operation has no effect on machine state during execution.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x5b),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 149),
-    },
+    evmCodesOpcodesLink(0x5b),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 149),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/controlFlow/jumpi.ts
+++ b/src/chains/mainnet/vm/opcodes/controlFlow/jumpi.ts
@@ -36,14 +36,8 @@ export const jumpi: Omit<Opcode, 'examples'> = {
     'The program counter (PC) is a byte offset in the deployed code. It indicates which instruction will be executed next. When an ADD is executed, for example, the PC is incremented by 1, since the instruction is 1 byte. The PUSH instructions are bigger than one byte, and so will increment the counter accordingly. The JUMPI instruction may alter the program counter, thus breaking the linear path of the execution to another point in the deployed code. It is used to implement functionalities like loops and conditions.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x57),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 70),
-    },
+    evmCodesOpcodesLink(0x57),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 70),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/controlFlow/pc.ts
+++ b/src/chains/mainnet/vm/opcodes/controlFlow/pc.ts
@@ -27,14 +27,8 @@ export const pc: Omit<Opcode, 'examples'> = {
     'The program counter (PC) is a byte offset in the deployed code. It indicates which instruction will be executed next. When an ADD is executed, for example, the PC is incremented by 1, since the instruction is 1 byte. The PUSH instructions are bigger than one byte, and so will increment the counter accordingly.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x58),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 101),
-    },
+    evmCodesOpcodesLink(0x58),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 101),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/controlFlow/stop.ts
+++ b/src/chains/mainnet/vm/opcodes/controlFlow/stop.ts
@@ -11,14 +11,8 @@ export const stop: Omit<Opcode, 'examples' | 'errorCases'> = {
     'Exits the current context successfully. When a call is executed on an address with no code and the EVM tries to read the code data, the default value is returned, 0, which corresponds to this instruction and halts the execution.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x00),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.ControlFlow, 23),
-    },
+    evmCodesOpcodesLink(0x00),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.ControlFlow, 23),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/address.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/address.ts
@@ -26,14 +26,8 @@ export const address: Opcode = {
   playgroundLink: evmCodesPlaygroundLink('%27ADDRESS%27_'),
   errorCases: ['Not enough gas', 'Stack overflow'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x30),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 40),
-    },
+    evmCodesOpcodesLink(0x30),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 40),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/balance.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/balance.ts
@@ -44,14 +44,8 @@ export const balance: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x31),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 63),
-    },
+    evmCodesOpcodesLink(0x31),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 63),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/basefee.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/basefee.ts
@@ -26,14 +26,8 @@ export const basefee: Opcode = {
   playgroundLink: evmCodesPlaygroundLink('%27BASEFEE%27_'),
   errorCases: ['Not enough gas', 'Stack overflow'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x48),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 517),
-    },
+    evmCodesOpcodesLink(0x48),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 517),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.London),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/calldatacopy.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/calldatacopy.ts
@@ -89,7 +89,7 @@ export const calldatacopy: Opcode = {
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
     evmCodesOpcodesLink(0x37),
-    'https://www.evm.codes/about#memoryexpansion',
+    '[evm.codes, Memory Expansion](https://www.evm.codes/about#memoryexpansion)',
     ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 212),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),

--- a/src/chains/mainnet/vm/opcodes/environment/calldatacopy.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/calldatacopy.ts
@@ -88,18 +88,9 @@ export const calldatacopy: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x37),
-    },
-    {
-      name: 'memory expansion',
-      url: 'https://www.evm.codes/about#memoryexpansion',
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 212),
-    },
+    evmCodesOpcodesLink(0x37),
+    'https://www.evm.codes/about#memoryexpansion',
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 212),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/calldataload.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/calldataload.ts
@@ -42,14 +42,8 @@ export const calldataload: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x35),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 163),
-    },
+    evmCodesOpcodesLink(0x35),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 163),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/calldatasize.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/calldatasize.ts
@@ -27,14 +27,8 @@ export const calldatasize: Opcode = {
   playgroundLink: evmCodesPlaygroundLink('%27CALLDATASIZE%27_&callData=0xFF'),
   errorCases: ['Not enough gas', 'Stack overflow'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x36),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 189),
-    },
+    evmCodesOpcodesLink(0x36),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 189),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/caller.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/caller.ts
@@ -27,14 +27,8 @@ export const caller: Opcode = {
   playgroundLink: evmCodesPlaygroundLink('%27CALLER%27_'),
   errorCases: ['Not enough gas', 'Stack overflow'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x33),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 117),
-    },
+    evmCodesOpcodesLink(0x33),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 117),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/callvalue.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/callvalue.ts
@@ -26,14 +26,8 @@ export const callvalue: Opcode = {
   playgroundLink: evmCodesPlaygroundLink('%27CALLVALUE%27_&callValue=123456789'),
   errorCases: ['Not enough gas', 'Stack overflow'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x34),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 140),
-    },
+    evmCodesOpcodesLink(0x34),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 140),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/codecopy.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/codecopy.ts
@@ -89,18 +89,9 @@ export const codecopy: Opcode = {
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   notes: ['For out of bound bytes, 0s will be copied'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x39),
-    },
-    {
-      name: 'memory expansion',
-      url: 'https://www.evm.codes/about#memoryexpansion',
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 270),
-    },
+    evmCodesOpcodesLink(0x39),
+    'https://www.evm.codes/about#memoryexpansion',
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 270),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/codecopy.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/codecopy.ts
@@ -90,7 +90,7 @@ export const codecopy: Opcode = {
   notes: ['For out of bound bytes, 0s will be copied'],
   references: [
     evmCodesOpcodesLink(0x39),
-    'https://www.evm.codes/about#memoryexpansion',
+    '[evm.codes, Memory Expansion](https://www.evm.codes/about#memoryexpansion)',
     ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 270),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),

--- a/src/chains/mainnet/vm/opcodes/environment/codesize.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/codesize.ts
@@ -31,14 +31,8 @@ export const codesize: Opcode = {
     'Each instruction occupies one byte. In the case of a PUSH instruction, the bytes that need to be pushed are encoded after that, it thus increases the codesize accordingly.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x38),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 247),
-    },
+    evmCodesOpcodesLink(0x38),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 247),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/extcodecopy.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/extcodecopy.ts
@@ -99,7 +99,7 @@ export const extcodecopy: Opcode = {
   notes: ['For out of bound bytes, 0s will be copied'],
   references: [
     evmCodesOpcodesLink(0x3c),
-    'https://www.evm.codes/about#memoryexpansion',
+    '[evm.codes, Memory Expansion](https://www.evm.codes/about#memoryexpansion)',
     ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 350),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),

--- a/src/chains/mainnet/vm/opcodes/environment/extcodecopy.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/extcodecopy.ts
@@ -98,18 +98,9 @@ export const extcodecopy: Opcode = {
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   notes: ['For out of bound bytes, 0s will be copied'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x3c),
-    },
-    {
-      name: 'memory expansion',
-      url: 'https://www.evm.codes/about#memoryexpansion',
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 350),
-    },
+    evmCodesOpcodesLink(0x3c),
+    'https://www.evm.codes/about#memoryexpansion',
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 350),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/extcodehash.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/extcodehash.ts
@@ -44,14 +44,8 @@ export const extcodehash: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x3f),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 444),
-    },
+    evmCodesOpcodesLink(0x3f),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 444),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Constantinople),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/extcodesize.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/extcodesize.ts
@@ -43,14 +43,8 @@ export const extcodesize: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x3b),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 324),
-    },
+    evmCodesOpcodesLink(0x3b),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 324),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/gasprice.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/gasprice.ts
@@ -26,14 +26,8 @@ export const gasprice: Opcode = {
   playgroundLink: evmCodesPlaygroundLink('%27GASPRICE%27_'),
   errorCases: ['Not enough gas', 'Stack overflow'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x3a),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 301),
-    },
+    evmCodesOpcodesLink(0x3a),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 301),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/origin.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/origin.ts
@@ -27,14 +27,8 @@ export const origin: Opcode = {
   playgroundLink: evmCodesPlaygroundLink('%27ORIGIN%27_'),
   errorCases: ['Not enough gas', 'Stack overflow'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x32),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 93),
-    },
+    evmCodesOpcodesLink(0x32),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 93),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/returndatacopy.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/returndatacopy.ts
@@ -95,7 +95,7 @@ export const returndatacopy: Opcode = {
   notes: ['A sub context can be created with CALL, CALLCODE, DELEGATECALL or STATICCALL'],
   references: [
     evmCodesOpcodesLink(0x3e),
-    'https://www.evm.codes/about#memoryexpansion',
+    '[evm.codes, Memory Expansion](https://www.evm.codes/about#memoryexpansion)',
     ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 406),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Byzantium),

--- a/src/chains/mainnet/vm/opcodes/environment/returndatacopy.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/returndatacopy.ts
@@ -94,18 +94,9 @@ export const returndatacopy: Opcode = {
   ],
   notes: ['A sub context can be created with CALL, CALLCODE, DELEGATECALL or STATICCALL'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x3e),
-    },
-    {
-      name: 'memory expansion',
-      url: 'https://www.evm.codes/about#memoryexpansion',
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 406),
-    },
+    evmCodesOpcodesLink(0x3e),
+    'https://www.evm.codes/about#memoryexpansion',
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 406),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Byzantium),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/returndatasize.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/returndatasize.ts
@@ -29,14 +29,8 @@ export const returndatasize: Opcode = {
   errorCases: ['Not enough gas', 'Stack overflow'],
   notes: ['A sub context can be created with CALL, CALLCODE, DELEGATECALL or STATICCALL'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x3d),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 384),
-    },
+    evmCodesOpcodesLink(0x3d),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 384),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Byzantium),
 };

--- a/src/chains/mainnet/vm/opcodes/environment/selfbalance.ts
+++ b/src/chains/mainnet/vm/opcodes/environment/selfbalance.ts
@@ -29,14 +29,8 @@ export const selfbalance: Opcode = {
     'Semantically equivalent of calling BALANCE with ADDRESS as parameter, but with a reduced gas cost.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x47),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 491),
-    },
+    evmCodesOpcodesLink(0x47),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Environment, 491),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Istanbul),
 };

--- a/src/chains/mainnet/vm/opcodes/keccak/keccak.ts
+++ b/src/chains/mainnet/vm/opcodes/keccak/keccak.ts
@@ -86,18 +86,9 @@ export const keccak: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x20),
-    },
-    {
-      name: 'memory expansion',
-      url: 'https://www.evm.codes/about#memoryexpansion',
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Keccak, 30),
-    },
+    evmCodesOpcodesLink(0x20),
+    'https://www.evm.codes/about#memoryexpansion',
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Keccak, 30),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/keccak/keccak.ts
+++ b/src/chains/mainnet/vm/opcodes/keccak/keccak.ts
@@ -87,7 +87,7 @@ export const keccak: Opcode = {
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
     evmCodesOpcodesLink(0x20),
-    'https://www.evm.codes/about#memoryexpansion',
+    '[evm.codes, Memory Expansion](https://www.evm.codes/about#memoryexpansion)',
     ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Keccak, 30),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),

--- a/src/chains/mainnet/vm/opcodes/log/log.ts
+++ b/src/chains/mainnet/vm/opcodes/log/log.ts
@@ -78,7 +78,7 @@ export const log = (n: number): Omit<Opcode, 'examples'> => {
     notes: ['This instruction has no effect on the EVM state'],
     references: [
       evmCodesOpcodesLink(number),
-      'https://www.evm.codes/about#memoryexpansion',
+      '[evm.codes, Memory Expansion](https://www.evm.codes/about#memoryexpansion)',
       ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Log, 84 + n),
     ],
     supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),

--- a/src/chains/mainnet/vm/opcodes/log/log.ts
+++ b/src/chains/mainnet/vm/opcodes/log/log.ts
@@ -77,18 +77,9 @@ export const log = (n: number): Omit<Opcode, 'examples'> => {
     ],
     notes: ['This instruction has no effect on the EVM state'],
     references: [
-      {
-        name: 'evm.codes',
-        url: evmCodesOpcodesLink(number),
-      },
-      {
-        name: 'memory expansion',
-        url: 'https://www.evm.codes/about#memoryexpansion',
-      },
-      {
-        name: 'execution-specs',
-        url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Log, 84 + n),
-      },
+      evmCodesOpcodesLink(number),
+      'https://www.evm.codes/about#memoryexpansion',
+      ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Log, 84 + n),
     ],
     supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
   };

--- a/src/chains/mainnet/vm/opcodes/memory/mload.ts
+++ b/src/chains/mainnet/vm/opcodes/memory/mload.ts
@@ -78,7 +78,7 @@ export const mload: Opcode = {
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
     evmCodesOpcodesLink(0x51),
-    'https://www.evm.codes/about#memoryexpansion',
+    '[evm.codes, Memory Expansion](https://www.evm.codes/about#memoryexpansion)',
     ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Memory, 90),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),

--- a/src/chains/mainnet/vm/opcodes/memory/mload.ts
+++ b/src/chains/mainnet/vm/opcodes/memory/mload.ts
@@ -77,18 +77,9 @@ export const mload: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x51),
-    },
-    {
-      name: 'memory expansion',
-      url: 'https://www.evm.codes/about#memoryexpansion',
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Memory, 90),
-    },
+    evmCodesOpcodesLink(0x51),
+    'https://www.evm.codes/about#memoryexpansion',
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Memory, 90),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/memory/msize.ts
+++ b/src/chains/mainnet/vm/opcodes/memory/msize.ts
@@ -26,14 +26,8 @@ export const msize: Omit<Opcode, 'examples'> = {
     'The memory is always fully accessible. What this instruction tracks is the highest offset that was accessed in the current execution. A first write or read to a bigger offset will trigger a memory expansion, which will cost gas. The size is always a multiple of a word (32 bytes).',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x59),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 120),
-    },
+    evmCodesOpcodesLink(0x59),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Arithmetic, 120),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/memory/mstore.ts
+++ b/src/chains/mainnet/vm/opcodes/memory/mstore.ts
@@ -72,18 +72,9 @@ export const mstore: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x52),
-    },
-    {
-      name: 'memory expansion',
-      url: 'https://www.evm.codes/about#memoryexpansion',
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Memory, 27),
-    },
+    evmCodesOpcodesLink(0x52),
+    'https://www.evm.codes/about#memoryexpansion',
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Memory, 27),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/memory/mstore.ts
+++ b/src/chains/mainnet/vm/opcodes/memory/mstore.ts
@@ -73,7 +73,7 @@ export const mstore: Opcode = {
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
     evmCodesOpcodesLink(0x52),
-    'https://www.evm.codes/about#memoryexpansion',
+    '[evm.codes, Memory Expansion](https://www.evm.codes/about#memoryexpansion)',
     ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Memory, 27),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),

--- a/src/chains/mainnet/vm/opcodes/memory/mstore8.ts
+++ b/src/chains/mainnet/vm/opcodes/memory/mstore8.ts
@@ -73,14 +73,8 @@ export const mstore8: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x53),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Memory, 58),
-    },
+    evmCodesOpcodesLink(0x53),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Memory, 58),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/stack/dup.ts
+++ b/src/chains/mainnet/vm/opcodes/stack/dup.ts
@@ -69,14 +69,8 @@ const dup = (n: number): Opcode => {
     ),
     errorCases: ['Not enough gas', 'Not enough values on the stack', 'Stack overflow'],
     references: [
-      {
-        name: 'evm.codes',
-        url: evmCodesOpcodesLink(number),
-      },
-      {
-        name: 'execution-specs',
-        url: ethSpecsOpcodeSrc(CURRENT_MAINNET_HARDFORK, OpcodeGroup.Stack, 179 + n),
-      },
+      evmCodesOpcodesLink(number),
+      ethSpecsOpcodeSrc(CURRENT_MAINNET_HARDFORK, OpcodeGroup.Stack, 179 + n),
     ],
     supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
   };

--- a/src/chains/mainnet/vm/opcodes/stack/pop.ts
+++ b/src/chains/mainnet/vm/opcodes/stack/pop.ts
@@ -27,14 +27,8 @@ export const pop: Opcode = {
   playgroundLink: evmCodesPlaygroundLink('%27PUSH3%20125985%5CnPOP%27_'),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x50),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(CURRENT_MAINNET_HARDFORK, OpcodeGroup.Stack, 26),
-    },
+    evmCodesOpcodesLink(0x50),
+    ethSpecsOpcodeSrc(CURRENT_MAINNET_HARDFORK, OpcodeGroup.Stack, 26),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/stack/push.ts
+++ b/src/chains/mainnet/vm/opcodes/stack/push.ts
@@ -35,14 +35,8 @@ const push = (n: number): Opcode => {
       'The new value is put on top of the stack, incrementing all the other value indices. The values for a specific opcode thus have to be pushed in reverse order of the stack. For example, with MSTORE, the first value pushed would have to be value, and then offset.',
     ],
     references: [
-      {
-        name: 'evm.codes',
-        url: evmCodesOpcodesLink(number),
-      },
-      {
-        name: 'execution-specs',
-        url: ethSpecsOpcodeSrc(CURRENT_MAINNET_HARDFORK, OpcodeGroup.Stack, 146 + n),
-      },
+      evmCodesOpcodesLink(number),
+      ethSpecsOpcodeSrc(CURRENT_MAINNET_HARDFORK, OpcodeGroup.Stack, 146 + n),
     ],
     supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
   };
@@ -80,14 +74,8 @@ export const push0: Opcode = {
     'The new value is put on top of the stack, incrementing all the other value indices. The values for a specific opcode thus have to be pushed in reverse order of the stack. For example, with MSTORE, the first value pushed would have to be value, and then offset.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x5f),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(CURRENT_MAINNET_HARDFORK, OpcodeGroup.Stack, 146),
-    },
+    evmCodesOpcodesLink(0x5f),
+    ethSpecsOpcodeSrc(CURRENT_MAINNET_HARDFORK, OpcodeGroup.Stack, 146),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Shanghai),
 };

--- a/src/chains/mainnet/vm/opcodes/stack/swap.ts
+++ b/src/chains/mainnet/vm/opcodes/stack/swap.ts
@@ -73,14 +73,8 @@ const swap = (n: number): Opcode => {
     ),
     errorCases: ['Not enough gas', 'Not enough values on the stack'],
     references: [
-      {
-        name: 'evm.codes',
-        url: evmCodesOpcodesLink(number),
-      },
-      {
-        name: 'execution-specs',
-        url: ethSpecsOpcodeSrc(CURRENT_MAINNET_HARDFORK, OpcodeGroup.Stack, 196 + n),
-      },
+      evmCodesOpcodesLink(number),
+      ethSpecsOpcodeSrc(CURRENT_MAINNET_HARDFORK, OpcodeGroup.Stack, 196 + n),
     ],
     supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
   };

--- a/src/chains/mainnet/vm/opcodes/storage/sload.ts
+++ b/src/chains/mainnet/vm/opcodes/storage/sload.ts
@@ -64,14 +64,8 @@ export const sload: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x54),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Storage, 32),
-    },
+    evmCodesOpcodesLink(0x54),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Storage, 32),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/storage/sstore.ts
+++ b/src/chains/mainnet/vm/opcodes/storage/sstore.ts
@@ -117,14 +117,8 @@ if value != current_value
     'The current execution context is from a STATICCALL (since Byzantium fork)',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0x55),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Storage, 62),
-    },
+    evmCodesOpcodesLink(0x55),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.Storage, 62),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/system/call.ts
+++ b/src/chains/mainnet/vm/opcodes/system/call.ts
@@ -118,14 +118,8 @@ export const call: Omit<Opcode, 'examples'> = {
     'From the Tangerine Whistle fork, gas is capped at all but one 64th (remaining_gas / 64) of the remaining gas of the current context. If a call tries to send more, the gas is changed to match the maximum allowed.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0xf1),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 329),
-    },
+    evmCodesOpcodesLink(0xf1),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 329),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/system/callcode.ts
+++ b/src/chains/mainnet/vm/opcodes/system/callcode.ts
@@ -109,14 +109,8 @@ export const callcode: Omit<Opcode, 'examples'> = {
     'From the Tangerine Whistle fork, gas is capped at all but one 64th (remaining_gas / 64) of the remaining gas of the current context. If a call tries to send more, the gas is changed to match the maximum allowed.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0xf2),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 407),
-    },
+    evmCodesOpcodesLink(0xf2),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 407),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/system/create.ts
+++ b/src/chains/mainnet/vm/opcodes/system/create.ts
@@ -113,14 +113,8 @@ export const create: Opcode = {
     'Note that these failures only affect the return value and do not cause the calling context to revert (unlike the error cases below).',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0xf0),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 125),
-    },
+    evmCodesOpcodesLink(0xf0),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 125),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Constantinople),
 };

--- a/src/chains/mainnet/vm/opcodes/system/create2.ts
+++ b/src/chains/mainnet/vm/opcodes/system/create2.ts
@@ -104,14 +104,8 @@ export const create2: Omit<Opcode, 'examples'> = {
     'Note that these failures only affect the return value and do not cause the calling context to revert (unlike the error cases below).',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0xf5),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 180),
-    },
+    evmCodesOpcodesLink(0xf5),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 180),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Constantinople),
 };

--- a/src/chains/mainnet/vm/opcodes/system/delegatecall.ts
+++ b/src/chains/mainnet/vm/opcodes/system/delegatecall.ts
@@ -104,14 +104,8 @@ export const delegatecall: Omit<Opcode, 'examples'> = {
     'From the Tangerine Whistle fork, gas is capped at all but one 64th (remaining_gas / 64) of the remaining gas of the current context. If a call tries to send more, the gas is changed to match the maximum allowed.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0xf4),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 536),
-    },
+    evmCodesOpcodesLink(0xf4),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 536),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Homestead),
 };

--- a/src/chains/mainnet/vm/opcodes/system/invalid.ts
+++ b/src/chains/mainnet/vm/opcodes/system/invalid.ts
@@ -11,11 +11,6 @@ export const invalid: Omit<Opcode, 'minGas' | 'examples' | 'errorCases'> = {
     'Equivalent to REVERT (since Byzantium fork) with 0,0 as stack parameters, except that all the gas given to the current context is consumed.',
     'All the remaining gas in this context is consumed.',
   ],
-  references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0xfe),
-    },
-  ],
+  references: [evmCodesOpcodesLink(0xfe)],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/system/return.ts
+++ b/src/chains/mainnet/vm/opcodes/system/return.ts
@@ -73,14 +73,8 @@ export const _return: Opcode = {
   ),
   errorCases: ['Not enough gas', 'Not enough values on the stack'],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0xf3),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 233),
-    },
+    evmCodesOpcodesLink(0xf3),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 233),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Frontier),
 };

--- a/src/chains/mainnet/vm/opcodes/system/revert.ts
+++ b/src/chains/mainnet/vm/opcodes/system/revert.ts
@@ -74,14 +74,8 @@ export const revert: Opcode = {
     'Stop the current context execution, revert the state changes (see STATICCALL for a list of state changing opcodes) and return the unused gas to the caller. It also reverts the gas refund to its value before the current context. If the execution is stopped with REVERT, the value 0 is put on the stack of the calling context, which continues to execute normally. The return data of the calling context is set as the given chunk of memory of this context.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0xfd),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 656),
-    },
+    evmCodesOpcodesLink(0xfd),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 656),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Byzantium),
 };

--- a/src/chains/mainnet/vm/opcodes/system/selfdestruct.ts
+++ b/src/chains/mainnet/vm/opcodes/system/selfdestruct.ts
@@ -50,14 +50,8 @@ export const selfdestruct: Omit<Opcode, 'examples'> = {
     'The current account is registered to be destroyed, and will be at the end of the current transaction. The transfer of the current balance to the given account cannot fail. In particular, the destination account code (if any) is not executed, or, if the account does not exist, the balance is still added to the given address.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0xff),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 481),
-    },
+    evmCodesOpcodesLink(0xff),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 481),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Constantinople),
 };

--- a/src/chains/mainnet/vm/opcodes/system/staticcall.ts
+++ b/src/chains/mainnet/vm/opcodes/system/staticcall.ts
@@ -92,14 +92,8 @@ export const staticcall: Omit<Opcode, 'examples' | 'playgroundLink'> = {
     'From the Tangerine Whistle fork, gas is capped at all but one 64th (remaining_gas / 64) of the remaining gas of the current context. If a call tries to send more, the gas is changed to match the maximum allowed.',
   ],
   references: [
-    {
-      name: 'evm.codes',
-      url: evmCodesOpcodesLink(0xfa),
-    },
-    {
-      name: 'execution-specs',
-      url: ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 594),
-    },
+    evmCodesOpcodesLink(0xfa),
+    ethSpecsOpcodeSrc(MainnetHardfork.Shanghai, OpcodeGroup.System, 594),
   ],
   supportedHardforks: getHardforksFrom(MainnetHardfork.Byzantium),
 };

--- a/src/chains/optimism/signatureTypes.ts
+++ b/src/chains/optimism/signatureTypes.ts
@@ -5,7 +5,7 @@ const depositTx: SignatureType = {
   prefixByte: 0x7e,
   description: 'An L2 transaction that was derived from L1 and included in a L2 block',
   signedData: [
-    'keccak256(0x7E || rlp([sourceHash, from, to, mint, value, gas, isSystemTx, data]))',
+    '`keccak256(0x7E || rlp([sourceHash, from, to, mint, value, gas, isSystemTx, data]))`',
   ],
   signs: 'transaction',
   references: [

--- a/src/chains/optimism/vm/opcodes/block/coinbase.ts
+++ b/src/chains/optimism/vm/opcodes/block/coinbase.ts
@@ -18,9 +18,6 @@ export const coinbase: Omit<Opcode, 'supportedHardforks'> = {
     },
   ],
   references: [
-    {
-      name: 'Differences between Optimism and Ethereum opcodes',
-      url: 'https://community.optimism.io/docs/developers/build/differences/#opcode-differences',
-    },
+    'https://community.optimism.io/docs/developers/build/differences/#opcode-differences',
   ],
 };

--- a/src/chains/optimism/vm/opcodes/block/coinbase.ts
+++ b/src/chains/optimism/vm/opcodes/block/coinbase.ts
@@ -18,6 +18,6 @@ export const coinbase: Omit<Opcode, 'supportedHardforks'> = {
     },
   ],
   references: [
-    'https://community.optimism.io/docs/developers/build/differences/#opcode-differences',
+    '[Differences between Ethereum and OP Mainnet: Opcode Differences](https://community.optimism.io/docs/developers/build/differences/#opcode-differences)',
   ],
 };

--- a/src/chains/optimism/vm/opcodes/block/prevrandao.ts
+++ b/src/chains/optimism/vm/opcodes/block/prevrandao.ts
@@ -14,13 +14,7 @@ export const prevrandao: Omit<Opcode, 'supportedHardforks'> = {
   description:
     "Returns the random output of the L1 beacon chain's randomness oracle. This value lags behind the L1 block's prevrandao value by approximately 5 L1 blocks, and is updated when the `L1BlockInfo` predeploy is updated.",
   references: [
-    {
-      name: 'Deriving the Transaction List',
-      url: 'https://github.com/ethereum-optimism/optimism/blob/develop/specs/derivation.md#building-individual-payload-attributes',
-    },
-    {
-      name: 'EVM Diff Issue #21',
-      url: 'https://github.com/mds1/evm-diff/issues/21',
-    },
+    'https://github.com/ethereum-optimism/optimism/blob/develop/specs/derivation.md#building-individual-payload-attributes',
+    'https://github.com/mds1/evm-diff/issues/21',
   ],
 };

--- a/src/chains/optimism/vm/opcodes/environment/caller.ts
+++ b/src/chains/optimism/vm/opcodes/environment/caller.ts
@@ -14,13 +14,7 @@ export const caller: Omit<Opcode, 'supportedHardforks'> = {
     },
   ],
   references: [
-    {
-      name: 'Differences between Optimism and Ethereum',
-      url: 'https://community.optimism.io/docs/developers/build/differences/#opcode-differences',
-    },
-    {
-      name: 'Aliased address',
-      url: 'https://community.optimism.io/docs/developers/build/differences/#address-aliasing',
-    },
+    'https://community.optimism.io/docs/developers/build/differences/#opcode-differences',
+    'https://community.optimism.io/docs/developers/build/differences/#address-aliasing',
   ],
 };

--- a/src/chains/optimism/vm/opcodes/environment/caller.ts
+++ b/src/chains/optimism/vm/opcodes/environment/caller.ts
@@ -14,7 +14,7 @@ export const caller: Omit<Opcode, 'supportedHardforks'> = {
     },
   ],
   references: [
-    'https://community.optimism.io/docs/developers/build/differences/#opcode-differences',
-    'https://community.optimism.io/docs/developers/build/differences/#address-aliasing',
+    '[Opcode Differences between Ethereum and OP Mainnet]([Differences between Ethereum and OP Mainnet: Opcode Differences](https://community.optimism.io/docs/developers/build/differences/#opcode-differences))',
+    '[Differences between Ethereum and OP Mainnet: Address Aliasing](https://community.optimism.io/docs/developers/build/differences/#address-aliasing)',
   ],
 };

--- a/src/chains/optimism/vm/opcodes/environment/origin.ts
+++ b/src/chains/optimism/vm/opcodes/environment/origin.ts
@@ -14,7 +14,7 @@ export const origin: Omit<Opcode, 'supportedHardforks'> = {
     },
   ],
   references: [
-    'https://community.optimism.io/docs/developers/build/differences/#opcode-differences',
-    'https://community.optimism.io/docs/developers/build/differences/#address-aliasing',
+    '[Differences between Ethereum and OP Mainnet: Opcode Differences](https://community.optimism.io/docs/developers/build/differences/#opcode-differences)',
+    '[Differences between Ethereum and OP Mainnet: Address Aliasing](https://community.optimism.io/docs/developers/build/differences/#address-aliasing)',
   ],
 };

--- a/src/chains/optimism/vm/opcodes/environment/origin.ts
+++ b/src/chains/optimism/vm/opcodes/environment/origin.ts
@@ -14,13 +14,7 @@ export const origin: Omit<Opcode, 'supportedHardforks'> = {
     },
   ],
   references: [
-    {
-      name: 'Differences between Optimism and Ethereum',
-      url: 'https://community.optimism.io/docs/developers/build/differences/#opcode-differences',
-    },
-    {
-      name: 'Aliased address',
-      url: 'https://community.optimism.io/docs/developers/build/differences/#address-aliasing',
-    },
+    'https://community.optimism.io/docs/developers/build/differences/#opcode-differences',
+    'https://community.optimism.io/docs/developers/build/differences/#address-aliasing',
   ],
 };

--- a/src/chains/optimism/vm/opcodes/stack/push0.ts
+++ b/src/chains/optimism/vm/opcodes/stack/push0.ts
@@ -7,6 +7,6 @@ export const push0: Omit<Opcode, 'supportedHardforks'> = {
   description:
     'The opcode is not supported yet, but will be added in a future hardfork. This means you cannot yet use Solidity 0.8.20 or later with an `evm_version` of Shanghai.',
   references: [
-    'https://community.optimism.io/docs/developers/build/differences/#opcode-differences',
+    '[Differences between Ethereum and OP Mainnet: Opcode Differences](https://community.optimism.io/docs/developers/build/differences/#opcode-differences)',
   ],
 };

--- a/src/chains/optimism/vm/opcodes/stack/push0.ts
+++ b/src/chains/optimism/vm/opcodes/stack/push0.ts
@@ -7,9 +7,6 @@ export const push0: Omit<Opcode, 'supportedHardforks'> = {
   description:
     'The opcode is not supported yet, but will be added in a future hardfork. This means you cannot yet use Solidity 0.8.20 or later with an `evm_version` of Shanghai.',
   references: [
-    {
-      name: 'Differences between Optimism and Ethereum opcodes',
-      url: 'https://community.optimism.io/docs/developers/build/differences/#opcode-differences',
-    },
+    'https://community.optimism.io/docs/developers/build/differences/#opcode-differences',
   ],
 };

--- a/src/chains/optimism/vm/predeploys.ts
+++ b/src/chains/optimism/vm/predeploys.ts
@@ -1,6 +1,8 @@
 import { Predeploy } from '@/types';
 
-// https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md
+const PREDEPLOYS_SPEC =
+  'https://github.com/ethereum-optimism/optimism/blob/47aec81ae66f9833afc5a65cd43a17d49edfea09/specs/predeploys.md';
+
 export const predeploys: Predeploy[] = [
   {
     address: '0x4200000000000000000000000000000000000000',
@@ -26,7 +28,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0xc0D3C0d3C0d3C0D3c0d3C0d3c0D3C0d3c0d30000',
     deprecated: true,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
   {
     address: '0x4200000000000000000000000000000000000002',
@@ -60,7 +62,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0xc0d3c0d3C0d3c0D3c0d3C0D3c0d3C0d3c0D30002',
     deprecated: true,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
   {
     address: '0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000',
@@ -94,7 +96,7 @@ export const predeploys: Predeploy[] = [
       'function transferFrom(address, address, uint256) returns (bool)',
     ],
     deprecated: true,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
   {
     address: '0x4200000000000000000000000000000000000006',
@@ -120,8 +122,8 @@ export const predeploys: Predeploy[] = [
     ],
     deprecated: false,
     references: [
-      'https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md',
-      'https://help.optimism.io/hc/en-us/articles/4417948883611-What-is-ETH-WETH-How-do-they-interact-',
+      PREDEPLOYS_SPEC,
+      '[What is ETH? WETH? How do they interact?](https://help.optimism.io/hc/en-us/articles/4417948883611-What-is-ETH-WETH-How-do-they-interact-)',
     ],
   },
   {
@@ -170,7 +172,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0xC0d3c0d3c0D3c0D3C0d3C0D3C0D3c0d3c0d30007',
     deprecated: false,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
   {
     address: '0x4200000000000000000000000000000000000010',
@@ -216,7 +218,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0xC0d3c0d3c0D3c0d3C0D3c0D3C0d3C0D3C0D30010',
     deprecated: false,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
   {
     address: '0x4200000000000000000000000000000000000011',
@@ -231,7 +233,7 @@ export const predeploys: Predeploy[] = [
       'receive() external payable',
     ],
     deprecated: false,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
   {
     address: '0x4200000000000000000000000000000000000012',
@@ -261,7 +263,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0xc0D3c0d3C0d3c0d3c0D3c0d3c0D3c0D3c0D30012',
     deprecated: false,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
   {
     address: '0x4200000000000000000000000000000000000013',
@@ -288,7 +290,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0xC0D3C0d3C0D3c0D3C0d3c0D3C0d3c0d3C0d30013',
     deprecated: true,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
   {
     address: '0x420000000000000000000000000000000000000F',
@@ -321,7 +323,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0xc0d3C0d3C0d3c0D3C0D3C0d3C0d3C0D3C0D3000f',
     deprecated: false,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
   {
     address: '0x4200000000000000000000000000000000000042',
@@ -364,7 +366,7 @@ export const predeploys: Predeploy[] = [
       'function transferOwnership(address newOwner)',
     ],
     deprecated: false,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
   {
     address: '0x4200000000000000000000000000000000000015',
@@ -398,7 +400,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0xc0d3C0D3C0D3c0D3C0D3C0d3C0D3c0D3c0d30015',
     deprecated: false,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
   {
     address: '0x4200000000000000000000000000000000000016',
@@ -430,7 +432,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0xC0D3C0d3C0d3c0d3C0d3C0D3c0D3c0d3c0D30016',
     deprecated: false,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
   {
     address: '0x4200000000000000000000000000000000000014',
@@ -464,7 +466,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0xC0D3c0d3c0d3c0d3c0D3C0d3C0D3C0D3c0d30014',
     deprecated: false,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
   {
     address: '0x4200000000000000000000000000000000000017',
@@ -494,7 +496,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0xc0d3C0d3C0d3C0d3C0d3c0d3C0D3C0d3C0D30017',
     deprecated: false,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
   {
     address: '0x4200000000000000000000000000000000000018',
@@ -535,7 +537,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0xC0d3C0D3c0d3C0d3c0d3c0D3C0D3C0d3C0D30018',
     deprecated: false,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
   {
     address: '0x4200000000000000000000000000000000000019',
@@ -566,7 +568,7 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0xC0d3c0D3c0d3C0D3C0D3C0d3c0D3C0D3c0d30019',
     deprecated: false,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
   {
     address: '0x420000000000000000000000000000000000001a',
@@ -597,6 +599,6 @@ export const predeploys: Predeploy[] = [
     ],
     logicAddress: '0xc0D3c0D3C0d3c0d3c0d3C0d3c0d3C0d3C0D3001A',
     deprecated: false,
-    references: ['https://github.com/ethereum-optimism/optimism/blob/develop/specs/predeploys.md'],
+    references: [PREDEPLOYS_SPEC],
   },
 ];

--- a/src/chains/optimism/vm/predeploys.ts
+++ b/src/chains/optimism/vm/predeploys.ts
@@ -6,7 +6,7 @@ const PREDEPLOYS_SPEC =
 export const predeploys: Predeploy[] = [
   {
     address: '0x4200000000000000000000000000000000000000',
-    name: 'LegacyMessagePasser',
+    name: '`LegacyMessagePasser`',
     description: 'Stores commitments to withdrawal transactions before the Bedrock upgrade.',
     proxyAbi: [
       'constructor(address _admin)',
@@ -32,7 +32,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x4200000000000000000000000000000000000002',
-    name: 'DeployerWhitelist',
+    name: '`DeployerWhitelist`',
     description:
       'Defined a list of accounts that were allowed to deploy contracts during the initial phases of Optimism.',
     proxyAbi: [
@@ -66,7 +66,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000',
-    name: 'LegacyERC20ETH',
+    name: '`LegacyERC20ETH`',
     description: 'Represents all Ether in the system before Bedrock.',
     logicAbi: [
       'constructor()',
@@ -100,7 +100,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x4200000000000000000000000000000000000006',
-    name: 'WETH9',
+    name: '`WETH9`',
     description: "Wrapped Ether contract, behaves identically to mainnet's canonical WETH.",
     logicAbi: [
       'event Approval(address indexed src, address indexed guy, uint256 wad)',
@@ -128,7 +128,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x4200000000000000000000000000000000000007',
-    name: 'L2CrossDomainMessenger',
+    name: '`L2CrossDomainMessenger`',
     description:
       'Provides a higher level API for sending cross-domain messages, compared to directly calling L2ToL1MessagePasser.',
     proxyAbi: [
@@ -176,7 +176,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x4200000000000000000000000000000000000010',
-    name: 'L2StandardBridge',
+    name: '`L2StandardBridge`',
     description:
       'Higher level API built on top of the L2CrossDomainMessenger that gives a standard interface for sending ETH or ERC20 tokens across domains.',
     proxyAbi: [
@@ -222,7 +222,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x4200000000000000000000000000000000000011',
-    name: 'SequencerFeeVault',
+    name: '`SequencerFeeVault`',
     description:
       'Accumulates any transaction priority fees and is the value of block.coinbase. When enough fees accumulate in this account, they can be withdrawn to an immutable L1 address.',
     logicAbi: [
@@ -237,7 +237,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x4200000000000000000000000000000000000012',
-    name: 'OptimismMintableERC20Factory',
+    name: '`OptimismMintableERC20Factory`',
     description:
       'Responsible for creating ERC20 contracts on L2 that can be used for depositing native L1 tokens into.',
     proxyAbi: [
@@ -267,7 +267,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x4200000000000000000000000000000000000013',
-    name: 'L1BlockNumber',
+    name: '`L1BlockNumber`',
     description: 'Returns the last known L1 block number.',
     proxyAbi: [
       'constructor(address _admin)',
@@ -294,7 +294,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x420000000000000000000000000000000000000F',
-    name: 'GasPriceOracle',
+    name: '`GasPriceOracle`',
     description: 'Provides an API to return the L1 portion of the fee for a transaction.',
     proxyAbi: [
       'constructor(address _admin)',
@@ -327,7 +327,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x4200000000000000000000000000000000000042',
-    name: 'GovernanceToken',
+    name: '`GovernanceToken`',
     description: 'The Optimism (OP) token contract.',
     logicAbi: [
       'constructor()',
@@ -370,7 +370,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x4200000000000000000000000000000000000015',
-    name: 'L1Block',
+    name: '`L1Block`',
     description: 'Allows for L1 state to be accessed in L2.',
     proxyAbi: [
       'constructor(address _admin)',
@@ -404,7 +404,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x4200000000000000000000000000000000000016',
-    name: 'L2ToL1MessagePasser',
+    name: '`L2ToL1MessagePasser`',
     description: 'Stores commitments to withdrawal transactions.',
     proxyAbi: [
       'constructor(address _admin)',
@@ -436,7 +436,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x4200000000000000000000000000000000000014',
-    name: 'L2ERC721Bridge',
+    name: '`L2ERC721Bridge`',
     description:
       'Works together with the L1 ERC721 bridge to enable transfers of ERC721 tokens from Ethereum to Optimism.',
     proxyAbi: [
@@ -470,7 +470,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x4200000000000000000000000000000000000017',
-    name: 'OptimismMintableERC721Factory',
+    name: '`OptimismMintableERC721Factory`',
     description:
       'Responsible for creating ERC721 contracts on L2 that can be used for depositing native L1 NFTs into.',
     proxyAbi: [
@@ -500,7 +500,7 @@ export const predeploys: Predeploy[] = [
   },
   {
     address: '0x4200000000000000000000000000000000000018',
-    name: 'ProxyAdmin',
+    name: '`ProxyAdmin`',
     description: 'The owner of all of the proxy contracts set at the predeploys.',
     proxyAbi: [
       'constructor(address _admin)',

--- a/src/components/diff/DiffOpcodes.tsx
+++ b/src/components/diff/DiffOpcodes.tsx
@@ -5,6 +5,7 @@ import { classNames, formatPrefixByte } from '@/lib/utils';
 import { toUppercase } from '@/lib/utils';
 import { Example, Opcode, Variable } from '@/types';
 import { GasComputation } from '@/types/opcode';
+import { ExternalLink } from '../layout/ExternalLink';
 import { References } from './utils/References';
 
 type Props = {
@@ -76,10 +77,6 @@ const formatVariable = (v: Variable): JSX.Element => {
       )}
     </div>
   );
-};
-
-const formatReference = (ref: string): JSX.Element => {
-  return <References references={ref} />;
 };
 
 const formatExample = (e: Example, id: number): JSX.Element => {
@@ -221,10 +218,18 @@ const formatOpcode = (opcode: Opcode | undefined): JSX.Element => {
       {opcode.examples !== undefined && opcode.examples.length > 0 && (
         <>
           <h3 className={classNames('font-bold', 'mt-2')}>Examples</h3>
-          <p className='text-secondary text-sm'>
-            Stack inputs are shown on the left of the arrow symbol and stack outputs on the right.
-          </p>
-          {opcode.playgroundLink && formatReference(opcode.playgroundLink)}
+          <div className='text-secondary text-sm'>
+            Stack inputs are shown on the left of the arrow symbol and stack outputs on the right.{' '}
+            {opcode.playgroundLink && (
+              <span>
+                Or,{' '}
+                <ExternalLink className='text-sm' href={opcode.playgroundLink}>
+                  try it out
+                </ExternalLink>{' '}
+                on the playground.
+              </span>
+            )}
+          </div>
           <ul>
             {opcode.examples.map((e, id) => (
               <li key={id}>{formatExample(e, id)}</li>
@@ -235,16 +240,7 @@ const formatOpcode = (opcode: Opcode | undefined): JSX.Element => {
       {formatGasComputation(opcode.gasComputation)}
       {formatStringList('Error Cases', opcode.errorCases)}
       {formatStringList('Notes', opcode.notes)}
-      {opcode.references.length > 0 && (
-        <>
-          <h3 className={classNames('font-bold', 'mt-2')}>References</h3>
-          <ul>
-            {opcode.references.map((r, id) => (
-              <li key={id}>{formatReference(r)}</li>
-            ))}
-          </ul>
-        </>
-      )}
+      <References references={opcode.references} />
     </>
   );
 };

--- a/src/components/diff/DiffOpcodes.tsx
+++ b/src/components/diff/DiffOpcodes.tsx
@@ -1,12 +1,15 @@
+import { Disclosure } from '@headlessui/react';
+import { ChevronRightIcon } from '@heroicons/react/20/solid';
+import { Markdown } from '@/components/diff/utils/Markdown';
+import { References } from '@/components/diff/utils/References';
 import { RenderDiff } from '@/components/diff/utils/RenderDiff';
+import { ExternalLink } from '@/components/layout/ExternalLink';
 import { Copyable } from '@/components/ui/Copyable';
 import { CURRENT_MAINNET_HARDFORK } from '@/lib/constants';
 import { classNames, formatPrefixByte } from '@/lib/utils';
 import { toUppercase } from '@/lib/utils';
 import { Example, Opcode, Variable } from '@/types';
 import { GasComputation } from '@/types/opcode';
-import { ExternalLink } from '../layout/ExternalLink';
-import { References } from './utils/References';
 
 type Props = {
   base: Opcode[];
@@ -15,8 +18,9 @@ type Props = {
 };
 
 const formatHardfork = (array: string[]): JSX.Element => {
-  if (array == undefined || array.length == 0)
+  if (array == undefined || array.length == 0) {
     return <p>No information provided on supported hard forks.</p>;
+  }
 
   const length = array.length;
   if (length == CURRENT_MAINNET_HARDFORK + 1)
@@ -57,15 +61,19 @@ const formatVariables = (title: string, array?: Variable[]): JSX.Element => {
 
 const formatVariable = (v: Variable): JSX.Element => {
   return (
-    <div key={v.name}>
+    <div key={v.name} className='text-secondary'>
       <p>
-        <span className='text-secondary text-sm'>{v.name}</span>: {v.description}
+        <code className='text-sm'>{v.name}</code>: <span>{v.description}</span>
       </p>
       {v.expression && (
         <>
-          <div className='text-secondary text-sm'>
-            <h5 className={classNames('font-bold', 'mt-4')}>Sub-variables ({v.name})</h5>
-            {v.name} = {v.expression}
+          <div className='text-sm'>
+            <h5 className='text-primary mt-4 font-semibold'>
+              Sub-variables (<code>{v.name}</code>)
+            </h5>
+            <code>
+              {v.name} = {v.expression}
+            </code>
             {v.variables && (
               <>
                 <ul>{v.variables.map((subvariables) => formatVariable(subvariables))}</ul>
@@ -79,50 +87,102 @@ const formatVariable = (v: Variable): JSX.Element => {
   );
 };
 
+const formatExamples = (opcode: Opcode): JSX.Element => {
+  if (!opcode.examples || opcode.examples.length === 0) return <></>;
+  return (
+    <Disclosure>
+      {({ open }) => (
+        <>
+          <Disclosure.Button
+            className={classNames(
+              'flex items-center text-sm',
+              open ? 'text-secondary' : 'text-zinc-300 dark:text-zinc-600'
+            )}
+          >
+            Examples
+            <ChevronRightIcon
+              className={classNames('h-5 w-5', open ? 'rotate-90 transform' : '')}
+            />
+          </Disclosure.Button>
+          <Disclosure.Panel className={open ? 'mb-4' : ''}>
+            <div className='text-secondary text-sm'>
+              Stack inputs are shown on the left of the arrow symbol and stack outputs on the right.{' '}
+              {opcode.playgroundLink && (
+                <span>
+                  Or,{' '}
+                  <ExternalLink className='text-sm' href={opcode.playgroundLink}>
+                    try it out
+                  </ExternalLink>{' '}
+                  on the playground.
+                </span>
+              )}
+            </div>
+            <ul>
+              {opcode.examples.map((e, id) => (
+                <li key={id}>{formatExample(e, id)}</li>
+              ))}
+            </ul>
+          </Disclosure.Panel>
+        </>
+      )}
+    </Disclosure>
+  );
+};
+
 const formatExample = (e: Example, id: number): JSX.Element => {
   const input = e.input ? '[' + e.input.toString() + ']' : '[]';
   const output = '[' + (e.output ? e.output : '') + ']';
   return (
     <>
-      <h4 className={classNames('font-bold', 'mt-3')}>Example #{id}</h4>
-      {e.description && <p>{e.description}</p>}
-      {input} {'=>'} {output}
-      {e.memory && (
-        <>
-          <h5 className={classNames('font-bold', 'mt-4')}>Memory</h5>
-          <h6 className={classNames('font-bold', 'mt-5')}>{'>'} Before</h6>
-          <p>- Before: {e.memory.before ? e.memory.before : '[]'}</p>
-          <h6 className={classNames('font-bold', 'mt-5')}>{'>'} After</h6>
-          <p>- After: {e.memory.after ? e.memory.after : '[]'}</p>
-        </>
-      )}
-      {e.storage && (
-        <>
-          <h5 className={classNames('font-bold', 'mt-4')}>Storage</h5>
-          <h6 className={classNames('font-bold', 'mt-5')}>{'>'} Before</h6>
-          {e.storage.before && formatStorage(e.storage.before)}
-          <h6 className={classNames('font-bold', 'mt-5')}>{'>'} After</h6>
-          {e.storage.after && formatStorage(e.storage.after)}
-        </>
-      )}
-      {e.calldata && (
-        <>
-          <h5 className={classNames('font-bold', 'mt-4')}>Calldata</h5>
-          {e.calldata}
-        </>
-      )}
-      {e.code && (
-        <>
-          <h5 className={classNames('font-bold', 'mt-4')}>Code</h5>
-          {e.code}
-        </>
-      )}
-      {e.returndata && (
-        <>
-          <h5 className={classNames('font-bold', 'mt-4')}>Return Data</h5>
-          {e.returndata}
-        </>
-      )}
+      <h4 className='mt-3 font-semibold'>Example #{id}</h4>
+      <div className='ml-3'>
+        {e.description && <p>{e.description}</p>}
+        <code className='text-secondary text-sm'>
+          {input} {'=>'} {output}
+        </code>
+        {e.memory && (
+          <>
+            <h5 className='mt-4 font-bold'>Memory</h5>
+            <h6 className='text-secondary font-semibold'>Before</h6>
+            <code className='text-secondary text-sm'>
+              {e.memory.before ? e.memory.before : '[]'}
+            </code>
+            <h6 className='text-secondary mt-2 font-semibold'>After</h6>
+            <code className='text-secondary text-sm'>{e.memory.after ? e.memory.after : '[]'}</code>
+          </>
+        )}
+        {e.storage && (
+          <>
+            <h5 className='mt-4 font-bold'>Storage</h5>
+            <h6 className='text-secondary font-semibold'>Before</h6>
+            <code className='text-secondary text-sm'>
+              {e.storage.before && formatStorage(e.storage.before)}
+            </code>
+            <h6 className='text-secondary mt-2 font-semibold'>After</h6>
+            <code className='text-secondary text-sm'>
+              {e.storage.after && formatStorage(e.storage.after)}
+            </code>
+          </>
+        )}
+        {e.calldata && (
+          <>
+            <h5 className='mt-4 font-bold'>Calldata</h5>
+            <code className='text-secondary text-sm'>{e.calldata}</code>
+          </>
+        )}
+        {e.code && (
+          <>
+            <h5 className='mt-4 font-bold'>Code</h5>
+            <code className='text-secondary text-sm'>{e.code}</code>
+          </>
+        )}
+        {e.returndata && (
+          <>
+            <h5 className='mt-4 font-bold'>Return Data</h5>
+            <code className='text-secondary text-sm'>{e.returndata}</code>
+          </>
+        )}
+      </div>
     </>
   );
 };
@@ -143,52 +203,73 @@ const formatStorage = (record: Record<string, string>): JSX.Element => {
 const formatGasComputation = (gc: GasComputation | undefined): JSX.Element => {
   if (!gc) return <></>;
   return (
-    <>
-      <h3 className={classNames('font-bold', 'mt-2')}>Gas Computation</h3>
-      <p>The gas cost of the function.</p>
-      <p className='text-secondary text-sm'>gas_cost = static_gas_cost + dynamic_gas_cost</p>
-
-      <h4 className={classNames('font-bold', 'mt-4')}>{'>'} Static gas cost</h4>
-      {gc.staticGasCost && (
+    <Disclosure>
+      {({ open }) => (
         <>
-          <p className={classNames('text-secondary text-sm')}>
-            static_gas_cost = {gc.staticGasCost.expression}
-          </p>
-          {gc.staticGasCost.variables && (
-            <>
-              <h5 className={classNames('font-bold', 'mt-4')}>Sub-variables (static_gas_cost)</h5>
-              <ul>
-                {gc.staticGasCost.variables.map((v) => (
-                  <li key={v.name}>{formatVariable(v)}</li>
-                ))}
-              </ul>
-            </>
-          )}
+          <Disclosure.Button
+            className={classNames(
+              'flex items-center text-sm',
+              open ? 'text-secondary mt-4' : 'text-zinc-300 dark:text-zinc-600'
+            )}
+          >
+            Gas Computation
+            <ChevronRightIcon
+              className={classNames('h-5 w-5', open ? 'rotate-90 transform' : '')}
+            />
+          </Disclosure.Button>
+          <Disclosure.Panel className={open ? 'mb-4' : ''}>
+            <code className='text-secondary text-sm'>
+              gas_cost = static_gas_cost + dynamic_gas_cost
+            </code>
+
+            <div>
+              {gc.staticGasCost && (
+                <>
+                  <code className='text-secondary text-sm'>
+                    static_gas_cost = {gc.staticGasCost.expression}
+                  </code>
+                  {gc.staticGasCost.variables && (
+                    <>
+                      <h5 className='mt-4 font-bold'>Sub-variables (static_gas_cost)</h5>
+                      <ul>
+                        {gc.staticGasCost.variables.map((v) => (
+                          <li key={v.name}>{formatVariable(v)}</li>
+                        ))}
+                      </ul>
+                    </>
+                  )}
+                </>
+              )}
+            </div>
+
+            <div>
+              {gc.dynamicGasCost && (
+                <>
+                  <code className='text-secondary text-sm'>
+                    dynamic_gas_cost = {gc.dynamicGasCost.expression}
+                  </code>
+                  {gc.dynamicGasCost.variables && (
+                    <>
+                      <h5 className='mt-4 font-semibold'>
+                        Sub-variables (<code className='text-sm'>dynamic_gas_cost</code>)
+                      </h5>
+                      <ul>
+                        {gc.dynamicGasCost.variables.map((v) => (
+                          <li key={v.name}>{formatVariable(v)}</li>
+                        ))}
+                      </ul>
+                    </>
+                  )}
+                </>
+              )}
+            </div>
+
+            <h4 className='mt-3 font-semibold'>Refunds</h4>
+            <p className='text-secondary'>{gc.refunds || 'No refunds'}</p>
+          </Disclosure.Panel>
         </>
       )}
-
-      <h4 className={classNames('font-bold', 'mt-4')}>{'>'} Dynamic gas cost</h4>
-      {gc.dynamicGasCost && (
-        <>
-          <p className={classNames('text-secondary text-sm')}>
-            dynamic_gas_cost = {gc.dynamicGasCost.expression}
-          </p>
-          {gc.dynamicGasCost.variables && (
-            <>
-              <h5 className={classNames('font-bold', 'mt-4')}>Sub-variables (dynamic_gas_cost)</h5>
-              <ul>
-                {gc.dynamicGasCost.variables.map((v) => (
-                  <li key={v.name}>{formatVariable(v)}</li>
-                ))}
-              </ul>
-            </>
-          )}
-        </>
-      )}
-
-      <h4 className={classNames('font-bold', 'mt-4')}>{'>'} Refunds</h4>
-      <p>{gc.refunds}</p>
-    </>
+    </Disclosure>
   );
 };
 
@@ -210,37 +291,18 @@ const formatOpcode = (opcode: Opcode | undefined): JSX.Element => {
   if (!opcode) return <p>Not present</p>;
   return (
     <>
-      <p className='mb-4'>{opcode.description}</p>
+      <Markdown className='mb-4' content={opcode.description} />
       {formatHardfork(opcode.supportedHardforks)}
       <p className='text-secondary text-sm'>⛽️ Minimum Gas: {opcode.minGas}</p>
       {formatVariables('Inputs', opcode.inputs)}
       {formatVariables('Outputs', opcode.outputs)}
-      {opcode.examples !== undefined && opcode.examples.length > 0 && (
-        <>
-          <h3 className={classNames('font-bold', 'mt-2')}>Examples</h3>
-          <div className='text-secondary text-sm'>
-            Stack inputs are shown on the left of the arrow symbol and stack outputs on the right.{' '}
-            {opcode.playgroundLink && (
-              <span>
-                Or,{' '}
-                <ExternalLink className='text-sm' href={opcode.playgroundLink}>
-                  try it out
-                </ExternalLink>{' '}
-                on the playground.
-              </span>
-            )}
-          </div>
-          <ul>
-            {opcode.examples.map((e, id) => (
-              <li key={id}>{formatExample(e, id)}</li>
-            ))}
-          </ul>
-        </>
-      )}
-      {formatGasComputation(opcode.gasComputation)}
       {formatStringList('Error Cases', opcode.errorCases)}
       {formatStringList('Notes', opcode.notes)}
-      <References references={opcode.references} />
+      <div className='mt-4'>
+        {formatExamples(opcode)}
+        {formatGasComputation(opcode.gasComputation)}
+        <References references={opcode.references} />
+      </div>
     </>
   );
 };

--- a/src/components/diff/DiffOpcodes.tsx
+++ b/src/components/diff/DiffOpcodes.tsx
@@ -3,9 +3,9 @@ import { Copyable } from '@/components/ui/Copyable';
 import { CURRENT_MAINNET_HARDFORK } from '@/lib/constants';
 import { classNames, formatPrefixByte } from '@/lib/utils';
 import { toUppercase } from '@/lib/utils';
-import { Example, Opcode, Reference, Variable } from '@/types';
+import { Example, Opcode, Variable } from '@/types';
 import { GasComputation } from '@/types/opcode';
-import { ExternalLink } from '../layout/ExternalLink';
+import { References } from './utils/References';
 
 type Props = {
   base: Opcode[];
@@ -78,12 +78,8 @@ const formatVariable = (v: Variable): JSX.Element => {
   );
 };
 
-const formatReference = (r: Reference): JSX.Element => {
-  return (
-    <p className='text-secondary text-sm'>
-      <ExternalLink href={r.url} text={r.name ? r.name.toLowerCase() : 'link'} />
-    </p>
-  );
+const formatReference = (ref: string): JSX.Element => {
+  return <References references={ref} />;
 };
 
 const formatExample = (e: Example, id: number): JSX.Element => {
@@ -228,8 +224,7 @@ const formatOpcode = (opcode: Opcode | undefined): JSX.Element => {
           <p className='text-secondary text-sm'>
             Stack inputs are shown on the left of the arrow symbol and stack outputs on the right.
           </p>
-          {opcode.playgroundLink &&
-            formatReference({ name: '>> evm.codes playground link', url: opcode.playgroundLink })}
+          {opcode.playgroundLink && formatReference(opcode.playgroundLink)}
           <ul>
             {opcode.examples.map((e, id) => (
               <li key={id}>{formatExample(e, id)}</li>

--- a/src/components/diff/DiffPrecompiles.tsx
+++ b/src/components/diff/DiffPrecompiles.tsx
@@ -1,4 +1,5 @@
 import { Address, getAddress } from 'viem';
+import { ParseMarkdown } from '@/components/diff/utils/ParseMarkdown';
 import { References } from '@/components/diff/utils/References';
 import { RenderDiff } from '@/components/diff/utils/RenderDiff';
 import { Copyable } from '@/components/ui/Copyable';
@@ -14,8 +15,12 @@ const formatPrecompile = (contents: Precompile | undefined) => {
   if (!contents) return <p>Not present</p>;
   return (
     <>
-      <p>{contents.name}</p>
-      <p className='text-secondary text-sm'>{contents.description}</p>
+      <p>
+        <ParseMarkdown codeSize='0.9rem' content={contents.name} />
+      </p>
+      <p className='text-secondary text-sm'>
+        <ParseMarkdown content={contents.description} />
+      </p>
       <References references={contents.references} />
     </>
   );

--- a/src/components/diff/DiffPrecompiles.tsx
+++ b/src/components/diff/DiffPrecompiles.tsx
@@ -1,4 +1,5 @@
 import { Address, getAddress } from 'viem';
+import { References } from '@/components/diff/utils/References';
 import { RenderDiff } from '@/components/diff/utils/RenderDiff';
 import { Copyable } from '@/components/ui/Copyable';
 import { Precompile } from '@/types';
@@ -15,6 +16,7 @@ const formatPrecompile = (contents: Precompile | undefined) => {
     <>
       <p>{contents.name}</p>
       <p className='text-secondary text-sm'>{contents.description}</p>
+      <References references={contents.references} />
     </>
   );
 };

--- a/src/components/diff/DiffPrecompiles.tsx
+++ b/src/components/diff/DiffPrecompiles.tsx
@@ -50,7 +50,9 @@ export const DiffPrecompiles = ({ base, target, onlyShowDiff }: Props) => {
               key={addr}
               className='grid grid-cols-12 items-center border-b border-zinc-500/10 py-6 dark:border-zinc-500/20'
             >
-              <Copyable className='col-span-2' content={formatAddress(addr)} textToCopy={addr} />
+              <div className='col-span-2'>
+                <Copyable content={formatAddress(addr)} textToCopy={addr} />
+              </div>
               <div className='col-span-5 pr-4'>{formatPrecompile(basePrecompile)}</div>
               <div className='col-span-5'>{formatPrecompile(targetPrecompile)}</div>
             </div>

--- a/src/components/diff/DiffPrecompiles.tsx
+++ b/src/components/diff/DiffPrecompiles.tsx
@@ -1,5 +1,5 @@
 import { Address, getAddress } from 'viem';
-import { ParseMarkdown } from '@/components/diff/utils/ParseMarkdown';
+import { Markdown } from '@/components/diff/utils/Markdown';
 import { References } from '@/components/diff/utils/References';
 import { RenderDiff } from '@/components/diff/utils/RenderDiff';
 import { Copyable } from '@/components/ui/Copyable';
@@ -16,10 +16,10 @@ const formatPrecompile = (contents: Precompile | undefined) => {
   return (
     <>
       <p>
-        <ParseMarkdown codeSize='0.9rem' content={contents.name} />
+        <Markdown codeSize='0.9rem' content={contents.name} />
       </p>
       <p className='text-secondary text-sm'>
-        <ParseMarkdown content={contents.description} />
+        <Markdown content={contents.description} />
       </p>
       <References references={contents.references} />
     </>

--- a/src/components/diff/DiffPrecompiles.tsx
+++ b/src/components/diff/DiffPrecompiles.tsx
@@ -21,7 +21,7 @@ const formatPrecompile = (contents: Precompile | undefined) => {
       <p className='text-secondary text-sm'>
         <Markdown content={contents.description} />
       </p>
-      <References references={contents.references} />
+      <References className='mt-4' references={contents.references} />
     </>
   );
 };

--- a/src/components/diff/DiffPrecompiles.tsx
+++ b/src/components/diff/DiffPrecompiles.tsx
@@ -1,8 +1,11 @@
+import { Disclosure } from '@headlessui/react';
+import { ChevronRightIcon } from '@heroicons/react/20/solid';
 import { Address, getAddress } from 'viem';
 import { Markdown } from '@/components/diff/utils/Markdown';
 import { References } from '@/components/diff/utils/References';
 import { RenderDiff } from '@/components/diff/utils/RenderDiff';
 import { Copyable } from '@/components/ui/Copyable';
+import { classNames } from '@/lib/utils';
 import { Precompile } from '@/types';
 
 type Props = {
@@ -11,17 +14,63 @@ type Props = {
   onlyShowDiff: boolean;
 };
 
-const formatPrecompile = (contents: Precompile | undefined) => {
-  if (!contents) return <p>Not present</p>;
+const Abi = ({ precompile }: { precompile: Precompile }) => {
+  let abi = (
+    <p className='text-sm italic'>
+      This interface is not yet rendered, but the data exists in the EVM Diff repository.
+    </p>
+  );
+
+  if ('logicAbi' in precompile && !precompile.logicAbi.length) {
+    abi = <p className='text-sm'>ABI not found.</p>;
+  } else if ('logicAbi' in precompile && precompile.logicAbi.length > 0) {
+    abi = (
+      <ul>
+        {precompile.logicAbi.map((sig) => (
+          <li key={sig} className='my-2 text-xs'>
+            <code>{sig}</code>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  return (
+    <Disclosure>
+      {({ open }) => (
+        <>
+          <Disclosure.Button
+            className={classNames(
+              'flex items-center text-sm',
+              open ? 'text-secondary my-2' : 'text-zinc-300 dark:text-zinc-600'
+            )}
+          >
+            ABI
+            <ChevronRightIcon
+              className={classNames('h-5 w-5', open ? 'rotate-90 transform' : '')}
+            />
+          </Disclosure.Button>
+          <Disclosure.Panel className={open ? 'mb-2' : ''}>{abi}</Disclosure.Panel>
+        </>
+      )}
+    </Disclosure>
+  );
+};
+
+const formatPrecompile = (precompile: Precompile | undefined) => {
+  if (!precompile) return <p>Not present</p>;
   return (
     <>
       <p>
-        <Markdown codeSize='0.9rem' content={contents.name} />
+        <Markdown codeSize='0.9rem' content={precompile.name} />
       </p>
       <p className='text-secondary text-sm'>
-        <Markdown content={contents.description} />
+        <Markdown content={precompile.description} />
       </p>
-      <References className='mt-4' references={contents.references} />
+      <div className='mt-4'>
+        <Abi precompile={precompile} />
+        <References references={precompile.references} />
+      </div>
     </>
   );
 };

--- a/src/components/diff/DiffPredeploys.tsx
+++ b/src/components/diff/DiffPredeploys.tsx
@@ -1,4 +1,5 @@
 import { Address, getAddress } from 'viem';
+import { ParseMarkdown } from '@/components/diff/utils/ParseMarkdown';
 import { References } from '@/components/diff/utils/References';
 import { RenderDiff } from '@/components/diff/utils/RenderDiff';
 import { Copyable } from '@/components/ui/Copyable';
@@ -14,8 +15,12 @@ const formatPredeploy = (contents: Predeploy | undefined) => {
   if (!contents) return <p>Not present</p>;
   return (
     <>
-      <p>{contents.name}</p>
-      <p className='text-secondary text-sm'>{contents.description}</p>
+      <p>
+        <ParseMarkdown codeSize='0.9rem' content={contents.name} />
+      </p>
+      <p className='text-secondary text-sm'>
+        <ParseMarkdown content={contents.description} />
+      </p>
       <References references={contents.references} />
     </>
   );

--- a/src/components/diff/DiffPredeploys.tsx
+++ b/src/components/diff/DiffPredeploys.tsx
@@ -1,8 +1,11 @@
+import { Disclosure } from '@headlessui/react';
+import { ChevronRightIcon } from '@heroicons/react/20/solid';
 import { Address, getAddress } from 'viem';
 import { Markdown } from '@/components/diff/utils/Markdown';
 import { References } from '@/components/diff/utils/References';
 import { RenderDiff } from '@/components/diff/utils/RenderDiff';
 import { Copyable } from '@/components/ui/Copyable';
+import { classNames } from '@/lib/utils';
 import { Predeploy } from '@/types';
 
 type Props = {
@@ -11,17 +14,103 @@ type Props = {
   onlyShowDiff: boolean;
 };
 
-const formatPredeploy = (contents: Predeploy | undefined) => {
-  if (!contents) return <p>Not present</p>;
+const Abi = ({ predeploy }: { predeploy: Predeploy }) => {
+  const hasProxyAbi = 'proxyAbi' in predeploy && predeploy.proxyAbi.length > 0;
+  const hasLogicAbi = 'logicAbi' in predeploy && predeploy.logicAbi.length > 0;
+  const hasLogicAddress = 'logicAddress' in predeploy && predeploy.logicAddress.length > 0;
+
+  let proxyAbi = <></>;
+  let logicAbi = <></>;
+
+  if (!hasProxyAbi) {
+    proxyAbi = <p className='text-sm'>ABI not found.</p>;
+  } else if (hasProxyAbi) {
+    proxyAbi = (
+      <ul>
+        {predeploy.proxyAbi.map((sig) => (
+          <li key={sig} className='my-2 text-xs'>
+            <code>{sig}</code>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (!hasLogicAbi) {
+    logicAbi = <p className='text-sm'>ABI not found.</p>;
+  } else if (hasLogicAbi) {
+    logicAbi = (
+      <ul>
+        {predeploy.logicAbi.map((sig) => (
+          <li key={sig} className='my-2 text-xs'>
+            <code>{sig}</code>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  const proxyAbiContent = (
+    <>
+      <div className='font-semibold'>Proxy Contract ABI</div>
+      {proxyAbi}
+      <div className='mt-4 font-semibold'>Logic Contract ABI</div>
+      <div className='text-secondary text-sm'>
+        {hasLogicAddress && (
+          <div className='mt-2 flex flex-1 items-center'>
+            {/* For some reason the text is not horizontally aligned so we manually add some margin to fix it */}
+            <div className='mr-1' style={{ marginBottom: '0.2rem' }}>
+              Implementation at
+            </div>
+            <Copyable
+              content={formatAddress(predeploy.logicAddress)}
+              textToCopy={predeploy.logicAddress}
+            />
+          </div>
+        )}
+      </div>
+      {logicAbi}
+    </>
+  );
+
+  return (
+    <Disclosure>
+      {({ open }) => (
+        <>
+          <Disclosure.Button
+            className={classNames(
+              'flex items-center text-sm',
+              open ? 'text-secondary my-2' : 'text-zinc-300 dark:text-zinc-600'
+            )}
+          >
+            ABI
+            <ChevronRightIcon
+              className={classNames('h-5 w-5', open ? 'rotate-90 transform' : '')}
+            />
+          </Disclosure.Button>
+          <Disclosure.Panel className={open ? 'mb-2' : ''}>
+            {hasProxyAbi ? proxyAbiContent : logicAbi}
+          </Disclosure.Panel>
+        </>
+      )}
+    </Disclosure>
+  );
+};
+
+const formatPredeploy = (predeploy: Predeploy | undefined) => {
+  if (!predeploy) return <p>Not present</p>;
   return (
     <>
       <p>
-        <Markdown codeSize='0.9rem' content={contents.name} />
+        <Markdown codeSize='0.9rem' content={predeploy.name} />
       </p>
       <p className='text-secondary text-sm'>
-        <Markdown content={contents.description} />
+        <Markdown content={predeploy.description} />
       </p>
-      <References className='mt-4' references={contents.references} />
+      <div className='mt-4'>
+        <Abi predeploy={predeploy} />
+        <References references={predeploy.references} />
+      </div>
     </>
   );
 };

--- a/src/components/diff/DiffPredeploys.tsx
+++ b/src/components/diff/DiffPredeploys.tsx
@@ -21,7 +21,7 @@ const formatPredeploy = (contents: Predeploy | undefined) => {
       <p className='text-secondary text-sm'>
         <Markdown content={contents.description} />
       </p>
-      <References references={contents.references} />
+      <References className='mt-4' references={contents.references} />
     </>
   );
 };

--- a/src/components/diff/DiffPredeploys.tsx
+++ b/src/components/diff/DiffPredeploys.tsx
@@ -1,5 +1,5 @@
 import { Address, getAddress } from 'viem';
-import { ParseMarkdown } from '@/components/diff/utils/ParseMarkdown';
+import { Markdown } from '@/components/diff/utils/Markdown';
 import { References } from '@/components/diff/utils/References';
 import { RenderDiff } from '@/components/diff/utils/RenderDiff';
 import { Copyable } from '@/components/ui/Copyable';
@@ -16,10 +16,10 @@ const formatPredeploy = (contents: Predeploy | undefined) => {
   return (
     <>
       <p>
-        <ParseMarkdown codeSize='0.9rem' content={contents.name} />
+        <Markdown codeSize='0.9rem' content={contents.name} />
       </p>
       <p className='text-secondary text-sm'>
-        <ParseMarkdown content={contents.description} />
+        <Markdown content={contents.description} />
       </p>
       <References references={contents.references} />
     </>

--- a/src/components/diff/DiffPredeploys.tsx
+++ b/src/components/diff/DiffPredeploys.tsx
@@ -49,7 +49,9 @@ export const DiffPredeploys = ({ base, target, onlyShowDiff }: Props) => {
               key={addr}
               className='grid grid-cols-12 items-center border-b border-zinc-500/10 py-6 dark:border-zinc-500/20'
             >
-              <Copyable className='col-span-2' content={formatAddress(addr)} textToCopy={addr} />
+              <div className='col-span-2'>
+                <Copyable content={formatAddress(addr)} textToCopy={addr} />
+              </div>
               <div className='col-span-5 pr-4'>{formatPredeploy(basePredeploy)}</div>
               <div className='col-span-5'>{formatPredeploy(targetPredeploy)}</div>
             </div>

--- a/src/components/diff/DiffPredeploys.tsx
+++ b/src/components/diff/DiffPredeploys.tsx
@@ -1,4 +1,5 @@
 import { Address, getAddress } from 'viem';
+import { References } from '@/components/diff/utils/References';
 import { RenderDiff } from '@/components/diff/utils/RenderDiff';
 import { Copyable } from '@/components/ui/Copyable';
 import { Predeploy } from '@/types';
@@ -15,6 +16,7 @@ const formatPredeploy = (contents: Predeploy | undefined) => {
     <>
       <p>{contents.name}</p>
       <p className='text-secondary text-sm'>{contents.description}</p>
+      <References references={contents.references} />
     </>
   );
 };

--- a/src/components/diff/DiffSignatureTypes.tsx
+++ b/src/components/diff/DiffSignatureTypes.tsx
@@ -1,3 +1,4 @@
+import { ParseMarkdown } from '@/components/diff/utils/ParseMarkdown';
 import { References } from '@/components/diff/utils/References';
 import { RenderDiff } from '@/components/diff/utils/RenderDiff';
 import { Copyable } from '@/components/ui/Copyable';
@@ -14,8 +15,15 @@ const formatSigType = (contents: SignatureType | undefined) => {
   if (!contents) return <p>Not present</p>;
   return (
     <>
-      <p>{contents.description}</p>
-      <p className='text-secondary text-sm'>{contents.signedData}</p>
+      <p>
+        <ParseMarkdown content={contents.description} />
+      </p>
+      {contents.signedData?.map((data) => (
+        <p key={data} className='text-secondary mb-1 text-sm'>
+          <ParseMarkdown content={data} />
+        </p>
+      ))}
+
       <References references={contents.references} />
     </>
   );
@@ -28,6 +36,9 @@ export const DiffSignatureTypes = ({ base, target, onlyShowDiff }: Props) => {
 
   const diffContent = (
     <>
+      <p className='text-secondary mb-4 text-sm'>
+        The <code className='text-xs'>||</code> symbol indicates concatenation
+      </p>
       {prefixBytes.map((prefix) => {
         const baseSigType = base.find((s) => s.prefixByte === prefix);
         const targetSigType = target.find((s) => s.prefixByte === prefix);

--- a/src/components/diff/DiffSignatureTypes.tsx
+++ b/src/components/diff/DiffSignatureTypes.tsx
@@ -24,7 +24,7 @@ const formatSigType = (contents: SignatureType | undefined) => {
         </p>
       ))}
 
-      <References references={contents.references} />
+      <References className='mt-4' references={contents.references} />
     </>
   );
 };

--- a/src/components/diff/DiffSignatureTypes.tsx
+++ b/src/components/diff/DiffSignatureTypes.tsx
@@ -1,3 +1,4 @@
+import { References } from '@/components/diff/utils/References';
 import { RenderDiff } from '@/components/diff/utils/RenderDiff';
 import { Copyable } from '@/components/ui/Copyable';
 import { formatPrefixByte } from '@/lib/utils';
@@ -15,6 +16,7 @@ const formatSigType = (contents: SignatureType | undefined) => {
     <>
       <p>{contents.description}</p>
       <p className='text-secondary text-sm'>{contents.signedData}</p>
+      <References references={contents.references} />
     </>
   );
 };

--- a/src/components/diff/DiffSignatureTypes.tsx
+++ b/src/components/diff/DiffSignatureTypes.tsx
@@ -1,4 +1,4 @@
-import { ParseMarkdown } from '@/components/diff/utils/ParseMarkdown';
+import { Markdown } from '@/components/diff/utils/Markdown';
 import { References } from '@/components/diff/utils/References';
 import { RenderDiff } from '@/components/diff/utils/RenderDiff';
 import { Copyable } from '@/components/ui/Copyable';
@@ -16,11 +16,11 @@ const formatSigType = (contents: SignatureType | undefined) => {
   return (
     <>
       <p>
-        <ParseMarkdown content={contents.description} />
+        <Markdown content={contents.description} />
       </p>
       {contents.signedData?.map((data) => (
         <p key={data} className='text-secondary mb-1 text-sm'>
-          <ParseMarkdown content={data} />
+          <Markdown content={data} />
         </p>
       ))}
 

--- a/src/components/diff/DiffSignatureTypes.tsx
+++ b/src/components/diff/DiffSignatureTypes.tsx
@@ -41,7 +41,9 @@ export const DiffSignatureTypes = ({ base, target, onlyShowDiff }: Props) => {
               key={prefix}
               className='grid grid-cols-12 items-center border-b border-zinc-500/10 py-6 dark:border-zinc-500/20'
             >
-              <Copyable className='col-span-2' content={formatPrefixByte(prefix)} />
+              <div className='col-span-2'>
+                <Copyable content={formatPrefixByte(prefix)} />
+              </div>
               <div className='col-span-5 pr-4'>{formatSigType(baseSigType)}</div>
               <div className='col-span-5'>{formatSigType(targetSigType)}</div>
             </div>

--- a/src/components/diff/utils/Markdown.tsx
+++ b/src/components/diff/utils/Markdown.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { ExternalLink } from '@/components/layout/ExternalLink';
 
-export const ParseMarkdown: React.FC<{ content: string; codeSize?: string }> = ({
+export const Markdown: React.FC<{ content: string; codeSize?: string }> = ({
   content,
   codeSize,
 }) => {

--- a/src/components/diff/utils/Markdown.tsx
+++ b/src/components/diff/utils/Markdown.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { ExternalLink } from '@/components/layout/ExternalLink';
 
-export const Markdown: React.FC<{ content: string; codeSize?: string }> = ({
+export const Markdown: React.FC<{ content: string; codeSize?: string; className?: string }> = ({
   content,
   codeSize,
+  className,
 }) => {
   // --- Transform Content ---
   const transformURLs = (content: string) => {
@@ -34,6 +35,7 @@ export const Markdown: React.FC<{ content: string; codeSize?: string }> = ({
   // --- Render ---
   return (
     <ReactMarkdown
+      className={className}
       components={{
         // Make sure all links have the `hyperlink` class, and external links open in a new tab.
         a: ({ href, children }) => {

--- a/src/components/diff/utils/ParseMarkdown.tsx
+++ b/src/components/diff/utils/ParseMarkdown.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import { ExternalLink } from '@/components/layout/ExternalLink';
+
+export const ParseMarkdown: React.FC<{ content: string }> = ({ content }) => {
+  // First we look for any raw GitHub URLs and convert them to named links. For example, given:
+  //   https://github.com/OffchainLabs/go-ethereum/blob/dcd0ff9ad8b4c84a9456c6b37f9047233adf7181/core/types/transaction.go#L48
+  // It replaces it with:
+  //   [OffchainLabs/go-ethereum, `core/types/transaction.go#L48@dcd0ff9`](https://github.com/OffchainLabs/go-ethereum/blob/dcd0ff9ad8b4c84a9456c6b37f9047233adf7181/core/types/transaction.go#L48)
+  const transformGitHubURLs = (markdown: string) => {
+    const githubURLPattern =
+      /(https:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/([^/]+)\/([^#]+)#([^ ]+))/g;
+    return markdown.replace(
+      githubURLPattern,
+      (_match, fullUrl, user, repo, commit, path, _line) => {
+        return `[${user}/${repo}, \`${path}@${commit.substring(0, 7)}\`](${fullUrl})`;
+      }
+    );
+  };
+
+  const transformedContent = transformGitHubURLs(content);
+
+  // Now we render the markdown.
+  return (
+    <ReactMarkdown
+      components={{
+        // Make sure all links have the `hyperlink` class, and external links open in a new tab.
+        a: ({ href, children }) => {
+          if (!href) return <></>;
+          const isExternal = href.startsWith('http://') || href.startsWith('https://');
+          if (isExternal) return <ExternalLink href={href}>{children}</ExternalLink>;
+          return (
+            <a className='hyperlink' href={href}>
+              {children}
+            </a>
+          );
+        },
+        // Make sure all code blocks have a smaller font size because otherwise they look big
+        // relative to the text.
+        code: ({ node: _node, ...props }) => <code {...props} style={{ fontSize: '0.8rem' }} />,
+      }}
+    >
+      {transformedContent}
+    </ReactMarkdown>
+  );
+};

--- a/src/components/diff/utils/ParseMarkdown.tsx
+++ b/src/components/diff/utils/ParseMarkdown.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { ExternalLink } from '@/components/layout/ExternalLink';
 
-export const ParseMarkdown: React.FC<{ content: string }> = ({ content }) => {
+export const ParseMarkdown: React.FC<{ content: string; codeSize?: string }> = ({
+  content,
+  codeSize,
+}) => {
   // --- Transform Content ---
   const transformURLs = (content: string) => {
     // Define regex patterns for the different types of URLs we want to convert to named links.
@@ -46,7 +49,7 @@ export const ParseMarkdown: React.FC<{ content: string }> = ({ content }) => {
         // Make sure all code blocks have a smaller font size because otherwise they look big
         // relative to the text.
         code: ({ node: _node, inline: _inline, ...props }) => (
-          <code {...props} style={{ fontSize: '0.8rem' }} />
+          <code {...props} style={{ fontSize: codeSize || '0.8rem' }} />
         ),
       }}
     >

--- a/src/components/diff/utils/References.tsx
+++ b/src/components/diff/utils/References.tsx
@@ -1,7 +1,7 @@
 // This component is used to display the references for a section in a diff
 import { Disclosure } from '@headlessui/react';
 import { ChevronRightIcon } from '@heroicons/react/20/solid';
-import { ParseMarkdown } from '@/components/diff/utils/ParseMarkdown';
+import { Markdown } from '@/components/diff/utils/Markdown';
 import { classNames } from '@/lib/utils';
 
 export const References = ({ references }: { references: string[] | string }) => {
@@ -28,7 +28,7 @@ export const References = ({ references }: { references: string[] | string }) =>
                 {refs.map((reference) => {
                   return (
                     <li key={JSON.stringify(reference)} className='list-item'>
-                      <ParseMarkdown content={reference} />
+                      <Markdown content={reference} />
                     </li>
                   );
                 })}

--- a/src/components/diff/utils/References.tsx
+++ b/src/components/diff/utils/References.tsx
@@ -4,7 +4,13 @@ import { ChevronRightIcon } from '@heroicons/react/20/solid';
 import { Markdown } from '@/components/diff/utils/Markdown';
 import { classNames } from '@/lib/utils';
 
-export const References = ({ references, className }: { references: string[] | string, className?: string }) => {
+export const References = ({
+  references,
+  className,
+}: {
+  references: string[] | string;
+  className?: string;
+}) => {
   const refs = Array.isArray(references) ? references : [references];
 
   return (

--- a/src/components/diff/utils/References.tsx
+++ b/src/components/diff/utils/References.tsx
@@ -4,7 +4,9 @@ import { ChevronRightIcon } from '@heroicons/react/20/solid';
 import { ParseMarkdown } from '@/components/diff/utils/ParseMarkdown';
 import { classNames } from '@/lib/utils';
 
-export const References = ({ references }: { references: string[] }) => {
+export const References = ({ references }: { references: string[] | string }) => {
+  const refs = Array.isArray(references) ? references : [references];
+
   return (
     <>
       <Disclosure>
@@ -18,7 +20,7 @@ export const References = ({ references }: { references: string[] }) => {
             </Disclosure.Button>
             <Disclosure.Panel>
               <ul className='text-ellipses list-disc pl-4 text-sm'>
-                {references.map((reference) => {
+                {refs.map((reference) => {
                   return (
                     <li key={JSON.stringify(reference)} className='list-item'>
                       <ParseMarkdown content={reference} />

--- a/src/components/diff/utils/References.tsx
+++ b/src/components/diff/utils/References.tsx
@@ -12,7 +12,12 @@ export const References = ({ references }: { references: string[] | string }) =>
       <Disclosure>
         {({ open }) => (
           <>
-            <Disclosure.Button className='flex items-center text-sm'>
+            <Disclosure.Button
+              className={classNames(
+                'flex items-center text-sm',
+                open ? 'text-secondary' : 'text-zinc-300 dark:text-zinc-600'
+              )}
+            >
               References
               <ChevronRightIcon
                 className={classNames('h-5 w-5', open ? 'rotate-90 transform' : '')}

--- a/src/components/diff/utils/References.tsx
+++ b/src/components/diff/utils/References.tsx
@@ -1,0 +1,35 @@
+// This component is used to display the references for a section in a diff
+import { Disclosure } from '@headlessui/react';
+import { ChevronRightIcon } from '@heroicons/react/20/solid';
+import { ParseMarkdown } from '@/components/diff/utils/ParseMarkdown';
+import { classNames } from '@/lib/utils';
+
+export const References = ({ references }: { references: string[] }) => {
+  return (
+    <>
+      <Disclosure>
+        {({ open }) => (
+          <>
+            <Disclosure.Button className='flex items-center'>
+              References
+              <ChevronRightIcon
+                className={classNames('h-6 w-6', open ? 'rotate-90 transform' : '')}
+              />
+            </Disclosure.Button>
+            <Disclosure.Panel>
+              <ul className='text-ellipses list-disc pl-4 text-sm'>
+                {references.map((reference) => {
+                  return (
+                    <li key={JSON.stringify(reference)} className='list-item'>
+                      <ParseMarkdown content={reference} />
+                    </li>
+                  );
+                })}
+              </ul>
+            </Disclosure.Panel>
+          </>
+        )}
+      </Disclosure>
+    </>
+  );
+};

--- a/src/components/diff/utils/References.tsx
+++ b/src/components/diff/utils/References.tsx
@@ -8,18 +8,18 @@ export const References = ({ references }: { references: string[] | string }) =>
   const refs = Array.isArray(references) ? references : [references];
 
   return (
-    <>
+    <div className='mt-4'>
       <Disclosure>
         {({ open }) => (
           <>
-            <Disclosure.Button className='flex items-center'>
+            <Disclosure.Button className='flex items-center text-sm'>
               References
               <ChevronRightIcon
-                className={classNames('h-6 w-6', open ? 'rotate-90 transform' : '')}
+                className={classNames('h-5 w-5', open ? 'rotate-90 transform' : '')}
               />
             </Disclosure.Button>
             <Disclosure.Panel>
-              <ul className='text-ellipses list-disc pl-4 text-sm'>
+              <ol className='text-ellipses list-decimal pl-4 text-sm'>
                 {refs.map((reference) => {
                   return (
                     <li key={JSON.stringify(reference)} className='list-item'>
@@ -27,11 +27,11 @@ export const References = ({ references }: { references: string[] | string }) =>
                     </li>
                   );
                 })}
-              </ul>
+              </ol>
             </Disclosure.Panel>
           </>
         )}
       </Disclosure>
-    </>
+    </div>
   );
 };

--- a/src/components/diff/utils/References.tsx
+++ b/src/components/diff/utils/References.tsx
@@ -4,11 +4,11 @@ import { ChevronRightIcon } from '@heroicons/react/20/solid';
 import { Markdown } from '@/components/diff/utils/Markdown';
 import { classNames } from '@/lib/utils';
 
-export const References = ({ references }: { references: string[] | string }) => {
+export const References = ({ references, className }: { references: string[] | string, className?: string }) => {
   const refs = Array.isArray(references) ? references : [references];
 
   return (
-    <div className='mt-4'>
+    <div className={className}>
       <Disclosure>
         {({ open }) => (
           <>

--- a/src/components/layout/ExternalLink.tsx
+++ b/src/components/layout/ExternalLink.tsx
@@ -1,7 +1,11 @@
 type Props = {
   href: string;
   className?: string;
-} & ({ text: string; children?: never } | { text?: never; children: JSX.Element });
+} & (
+  | { text: string; children?: never }
+  | { text?: never; children: JSX.Element }
+  | { text?: never; children: React.ReactNode }
+);
 
 export const ExternalLink = ({ href, className, text, children }: Props) => {
   return (

--- a/src/components/ui/Toggle.tsx
+++ b/src/components/ui/Toggle.tsx
@@ -14,7 +14,7 @@ export const Toggle = ({ enabled, setEnabled, label }: Props) => {
         checked={enabled}
         onChange={setEnabled}
         className={classNames(
-          enabled ? 'bg-green-600' : 'bg-secondary',
+          enabled ? 'bg-green-600' : 'bg-primary',
           'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out'
         )}
       >

--- a/src/pages/diff.tsx
+++ b/src/pages/diff.tsx
@@ -101,7 +101,7 @@ const Diff = () => {
             const base = baseChain[section as keyof Chain];
             const target = targetChain[section as keyof Chain];
             return (
-              <div key={section} id={section}>
+              <div key={section} id={section} className='break-words'>
                 {/* Header */}
                 <Copyable
                   content={SECTION_MAP[section].title || section}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 export type { Chain } from './chain';
-export type { Variable, Example, Reference, Opcode } from './opcode';
+export type { Variable, Example, Opcode } from './opcode';
 export type { Precompile } from './precompile';
 export type { Predeploy } from './predeploy';
 export type { SignatureType } from './signatureType';

--- a/src/types/opcode.ts
+++ b/src/types/opcode.ts
@@ -34,11 +34,6 @@ export type GasComputation = {
   refunds?: string;
 };
 
-export type Reference = {
-  name: string;
-  url: string;
-};
-
 export type Opcode = {
   number: number;
   name: string;
@@ -51,6 +46,6 @@ export type Opcode = {
   playgroundLink?: string;
   errorCases: string[];
   notes?: string[];
-  references: Reference[];
+  references: string[];
   supportedHardforks: string[];
 };


### PR DESCRIPTION
- Add a `Markdown` component to parse markdown from the data in the `chains` folder. This allows us some control of formatting while defining data, but still keeps data and presentation mostly separated.
    - Plain URLs for sites frequently used as references (github, evm.codes, ethereum execution specs) are automatically replaced by formatted versions
    - Links are given the `hyperlink` class
- All references are hidden behind a collapsible block using the `References` component
- Opcode section now has examples and gas computation details hidden behind a collapsible block to simplify easy of reading
- Precompiles and Predeploys show ABI data when present (data for non-ABI interfaces, e.g. precompiles 0x01–0x09, are not yet rendered
- There's some code duplication, e.g. around the `Disclosure` component usage that can probably be extracted into a component, but we leave it for now 