### PR TITLE
feat: feature comparisons

### DIFF
--- a/src/components/features/FeatureTable.tsx
+++ b/src/components/features/FeatureTable.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { ChevronDownIcon } from '@heroicons/react/20/solid';
+import { chains } from '@/chains';
+
+export const FeatureTable = ({
+  kind,
+  name,
+  className,
+}: {
+  kind: string;
+  name: string;
+  className?: string;
+}) => {
+  const chainsArray = Object.values(chains);
+  const supportData = chainsArray.map((chain) => {
+    if (kind === 'opcode') {
+      const opcode = chain.opcodes.find((op) => op.name?.toLowerCase() === name.toLowerCase());
+      if (!opcode) return undefined;
+      return opcode.description?.includes('not supported') ? 'False' : 'True';
+    }
+  });
+  const adjustedChains = chainsArray.map((chain, i) => {
+    return { ...chain, supported: supportData[i] };
+  });
+
+  // --- Sorting and filtering ---
+  const [sortField, setSortField] = useState(null as 'name' | 'col1' | null);
+  const [sortDirection, setSortDirection] = useState('ascending');
+
+  const onHeaderClick = (field: 'name' | 'col1') => {
+    if (sortField === field) {
+      setSortDirection(sortDirection === 'ascending' ? 'descending' : 'ascending');
+    } else {
+      setSortField(field);
+      setSortDirection('ascending');
+    }
+  };
+
+  const sortedChains = adjustedChains.sort((a, b) => {
+    // Don't change default sort order if sort field is null.
+    if (sortField === null) return 0;
+    let aValue: string | number = 0;
+    let bValue: string | number = 0;
+
+    if (sortField === 'name') {
+      aValue = a.metadata.name.toLowerCase();
+      bValue = b.metadata.name.toLowerCase();
+    } else if (sortField === 'col1') {
+      aValue = a.supported?.toLowerCase() === 'true' ? 0 : 1;
+      bValue = b.supported?.toLowerCase() === 'true' ? 0 : 1;
+    }
+
+    if (sortDirection === 'ascending') {
+      return aValue > bValue ? 1 : aValue < bValue ? -1 : 0;
+    } else {
+      return aValue < bValue ? 1 : aValue > bValue ? -1 : 0;
+    }
+  });
+
+  return (
+    <div className={className}>
+      <table className='inline-block overflow-hidden rounded-md border border-zinc-200 shadow-sm dark:border-zinc-600 dark:shadow-md'>
+        <thead className='bg-primary'>
+          <tr>
+            <th
+              scope='col'
+              className='text-primary py-3.5 pl-4 pr-3 text-left text-sm font-semibold sm:pl-6'
+            >
+              <div
+                className='group inline-flex cursor-pointer rounded-md p-1 hover:bg-zinc-200 hover:dark:bg-zinc-700'
+                onClick={() => onHeaderClick('name')}
+              >
+                Name
+                <span className='text-primary ml-2 flex-none rounded'>
+                  <ChevronDownIcon className='h-5 w-5' aria-hidden='true' />
+                </span>
+              </div>
+            </th>
+            <th scope='col' className='text-primary px-3 py-3.5 text-left text-sm font-semibold'>
+              <div
+                className='group inline-flex cursor-pointer rounded-md p-1 hover:bg-zinc-200 hover:dark:bg-zinc-700'
+                onClick={() => onHeaderClick('col1')}
+              >
+                Is {name} supported?
+                <span className='text-primary ml-2 flex-none rounded'>
+                  <ChevronDownIcon className='h-5 w-5' aria-hidden='true' />
+                </span>
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody className='cursor-pointer divide-y-0 divide-zinc-200'>
+          {sortedChains.map((chain) => (
+            <tr key={chain.metadata.id} className='bg-secondary group'>
+              <td className='text-primary flex flex-col whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium sm:pl-6'>
+                {chain.metadata.name}
+              </td>
+              <td className='text-primary whitespace-nowrap px-3 py-4 text-center text-sm'>
+                {chain.supported}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/components/ui/BaseCombobox.tsx
+++ b/src/components/ui/BaseCombobox.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react';
+import { Combobox } from '@headlessui/react';
+import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid';
+import { classNames } from '@/lib/utils';
+
+type Option = {
+  name: string;
+  isHeader?: boolean;
+  [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+};
+
+export const BaseCombobox = ({
+  label,
+  options,
+  value,
+  onChange,
+  className,
+}: {
+  label: string;
+  options: Option[];
+  value: Option;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onChange: (opt: any) => void;
+  className?: string;
+}) => {
+  const [query, setQuery] = useState('');
+  const [option, setOption] = useState(value);
+
+  useEffect(() => {
+    setOption(value);
+  }, [value]);
+
+  const filteredOpts =
+    query === ''
+      ? options
+      : options.filter((opt) => {
+          return (
+            opt.name.toLowerCase().includes(query.toLowerCase()) ||
+            (opt.kind && String(opt.kind).toLowerCase().includes(query.toLowerCase()))
+          );
+        });
+
+  return (
+    <Combobox
+      as='div'
+      className={className}
+      value={option}
+      onChange={(val) => {
+        setOption(val);
+        onChange(val);
+      }}
+    >
+      <Combobox.Label className='text-primary block text-sm font-medium leading-6'>
+        {label}
+      </Combobox.Label>
+      <div className='relative mt-2'>
+        <Combobox.Input
+          className='text-primary bg-primary w-full rounded-md border-0 py-1.5 pl-3 pr-12 shadow-sm ring-1 ring-inset ring-zinc-300 focus:ring-2 focus:ring-inset focus:ring-green-600 sm:text-sm sm:leading-6'
+          onChange={(event) => setQuery(event.target.value)}
+          displayValue={(opt: Option) => opt.name}
+        />
+
+        <Combobox.Button className='absolute right-0 top-2 flex items-center rounded-r-md px-2 focus:outline-none'>
+          <ChevronUpDownIcon className='h-5 w-5 text-zinc-400' aria-hidden='true' />
+        </Combobox.Button>
+
+        {filteredOpts.length > 0 && (
+          <Combobox.Options className='bg-primary z-10 mt-1 w-full overflow-auto rounded-md py-1 text-base shadow-lg ring-1 ring-zinc-1000 ring-opacity-5 focus:outline-none sm:text-sm'>
+            {filteredOpts.map((opt, index) => (
+              <Combobox.Option
+                key={index}
+                value={opt}
+                disabled={opt.isHeader}
+                className={({ active }) =>
+                  classNames(
+                    'relative cursor-pointer select-none py-2 pl-3 pr-9',
+                    active ? 'text-primary bg-green-600/10 dark:bg-green-500/10' : 'text-primary'
+                  )
+                }
+              >
+                {({ active, selected }) => (
+                  <>
+                    <div className='flex items-center'>
+                      <span
+                        className={classNames(
+                          'ml-3 truncate',
+                          selected && 'font-semibold',
+                          opt.isHeader ? 'text-secondary ml-0' : ''
+                        )}
+                      >
+                        {opt.name}
+                      </span>
+                    </div>
+
+                    {selected && (
+                      <span
+                        className={classNames(
+                          'absolute inset-y-0 right-0 flex items-center pr-4',
+                          active ? 'text-primary' : 'text-green-600'
+                        )}
+                      >
+                        <CheckIcon className='h-5 w-5' aria-hidden='true' />
+                      </span>
+                    )}
+                  </>
+                )}
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+        )}
+      </div>
+    </Combobox>
+  );
+};

--- a/src/pages/features.tsx
+++ b/src/pages/features.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { chains } from '@/chains';
+import { BaseCombobox } from '@/components/ui/BaseCombobox';
+import { Chain } from '@/types';
+
+const Features = () => {
+  // --- URL Parsing ---
+  const router = useRouter();
+  const { name, kind } = router.query;
+
+  // --- Prepare options ---
+  type Kind = 'opcode'; // TODO Support more kinds.
+  type FeatureHeader = {
+    name: string;
+    isHeader: boolean;
+  };
+
+  type FeatureItem = {
+    name: string;
+    kind: Kind;
+  };
+
+  type Feature = FeatureHeader | FeatureItem;
+
+  const chainsArray: Chain[] = Object.values(chains);
+  const opcodeOptions = chainsArray
+    .map(({ opcodes }) => {
+      return opcodes.map(({ name }) => ({
+        name: name!.toLocaleUpperCase(),
+        kind: 'opcode' as Kind,
+      }));
+    })
+    .flat();
+
+  const options: Feature[] = [{ name: 'Opcodes', isHeader: true }, ...opcodeOptions];
+
+  // --- Form handling ---
+  const [option, setOption] = useState(options[1]);
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    router.push({
+      pathname: '/features',
+      query: option,
+    });
+  };
+
+  // --- Selector Div ---
+  const SelectorDiv = () => (
+    <main className='mx-auto max-w-7xl sm:px-6 lg:px-8'>
+      <div className='relative isolate overflow-hidden px-6 py-0 sm:rounded-3xl sm:px-24 sm:py-20'>
+        <h2 className='mx-auto max-w-2xl text-center text-3xl font-bold tracking-tight text-zinc-1000 dark:text-zinc-0 sm:text-4xl'>
+          Compare Feature Support
+        </h2>
+        <p className='text-secondary mx-auto mt-2 max-w-prose text-center text-lg leading-8'>
+          Choose an opcode and check its support across chains.
+        </p>
+        <p className='text-secondary mx-auto max-w-prose text-center text-sm italic leading-8'>
+          More feature comparisons coming soon!
+        </p>
+        <form className='mx-auto mt-6 max-w-md space-y-6' onSubmit={onSubmit}>
+          <BaseCombobox
+            label='Select a feature'
+            options={options}
+            value={option}
+            onChange={setOption}
+          />
+          <button type='submit' className='button flex w-full justify-center'>
+            View
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+
+  // --- Feature Table ---
+  const FeatureTable = () => (
+    <main>
+      <h2 className='mx-auto max-w-2xl text-center text-3xl font-bold tracking-tight text-zinc-1000 dark:text-zinc-0 sm:text-4xl'>
+        Compare {name} Support
+      </h2>
+    </main>
+  );
+
+  // --- Render ---
+  return <>{name && kind ? <FeatureTable /> : <SelectorDiv />}</>;
+};
+
+export default Features;

--- a/src/pages/features.tsx
+++ b/src/pages/features.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { ExclamationTriangleIcon } from '@heroicons/react/20/solid';
 import { chains } from '@/chains';
+import { FeatureTable } from '@/components/features/FeatureTable';
 import { BaseCombobox } from '@/components/ui/BaseCombobox';
 import { Chain } from '@/types';
 
@@ -10,7 +13,8 @@ const Features = () => {
   const { name, kind } = router.query;
 
   // --- Prepare options ---
-  type Kind = 'opcode'; // TODO Support more kinds.
+  // TODO Support more kinds.
+  type Kind = 'opcode';
   type FeatureHeader = {
     name: string;
     isHeader: boolean;
@@ -24,7 +28,7 @@ const Features = () => {
   type Feature = FeatureHeader | FeatureItem;
 
   const chainsArray: Chain[] = Object.values(chains);
-  const opcodeOptions = chainsArray
+  const allOpcodes = chainsArray
     .map(({ opcodes }) => {
       return opcodes.map(({ name }) => ({
         name: name!.toLocaleUpperCase(),
@@ -32,6 +36,10 @@ const Features = () => {
       }));
     })
     .flat();
+
+  const opcodeOptions = allOpcodes.filter((opcode, index, self) => {
+    return index === self.findIndex((o) => o.name === opcode.name);
+  });
 
   const options: Feature[] = [{ name: 'Opcodes', isHeader: true }, ...opcodeOptions];
 
@@ -75,16 +83,29 @@ const Features = () => {
   );
 
   // --- Feature Table ---
-  const FeatureTable = () => (
-    <main>
-      <h2 className='mx-auto max-w-2xl text-center text-3xl font-bold tracking-tight text-zinc-1000 dark:text-zinc-0 sm:text-4xl'>
-        Compare {name} Support
-      </h2>
-    </main>
-  );
+  const FeatureTableDiv = () => {
+    return (
+      <main>
+        <h2 className='mx-auto max-w-2xl text-center text-3xl font-bold tracking-tight text-zinc-1000 dark:text-zinc-0 sm:text-4xl'>
+          Compare {name} Support
+        </h2>
+        <div className='flex flex-col items-center'>
+          <FeatureTable kind={kind as string} name={name as string} className='mt-8 max-w-prose' />
+          <p className='text-secondary mx-auto mt-4 max-w-sm text-sm'>
+            <ExclamationTriangleIcon width='1rem' className='mr-2 inline-block text-amber-500' />
+            There may still be diffs between chains with the same support level. Be sure to{' '}
+            <Link className='hyperlink' href='/'>
+              view a diff
+            </Link>{' '}
+            of specific chains to see details.
+          </p>
+        </div>
+      </main>
+    );
+  };
 
   // --- Render ---
-  return <>{name && kind ? <FeatureTable /> : <SelectorDiv />}</>;
+  return <>{name && kind ? <FeatureTableDiv /> : <SelectorDiv />}</>;
 };
 
 export default Features;

--- a/src/pages/features.tsx
+++ b/src/pages/features.tsx
@@ -44,7 +44,9 @@ const Features = () => {
   const options: Feature[] = [{ name: 'Opcodes', isHeader: true }, ...opcodeOptions];
 
   // --- Form handling ---
-  const [option, setOption] = useState(options[1]);
+  // Set PUSH0 as the default.
+  const push0Index = options.findIndex((opt) => opt.name === 'PUSH0');
+  const [option, setOption] = useState(options[push0Index]);
 
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();


### PR DESCRIPTION
Initial implementation of a caniuse.com-like view to compare support of a given feature (e.g. opcode, transaction type, etc.) across chains. So far it only supports opcodes.

Supporting other things gets tricky, for example we have to be able to recognize that arbitrum's WETH and optimism's WETH are both WETH predeploys, so all chains have WETH, even though the names or addresses don't match. Maybe a good way to do this is add a `normalizedName` field to each type that we use to identify the same concept across chains

Usage:
- http://localhost:3000/features gives the home page where you can choose an opcde
- Clicking one takes you to e.g. http://localhost:3000/features?name=PUSH0&kind=opcode which shows the table for supported chains