### PR TITLE
feat: add deployed contracts

### DIFF
--- a/src/chains/arbitrum/deployedContracts.ts
+++ b/src/chains/arbitrum/deployedContracts.ts
@@ -1,0 +1,56 @@
+import { deployedContracts as mainnetDeployedContracts } from '@/chains/mainnet/deployedContracts';
+
+const arbitrumDeployedContracts = { ...mainnetDeployedContracts };
+arbitrumDeployedContracts['Wrapped Native Token'] = {
+  ...arbitrumDeployedContracts['Wrapped Native Token'],
+  address: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
+  references: [
+    ...arbitrumDeployedContracts['Wrapped Native Token'].references,
+    '[Arbitrum Docs: Smart contract addresses](https://docs.arbitrum.io/for-devs/useful-addresses#core-contracts-1)',
+  ],
+  proxyAbi: [
+    'constructor(address _logic, address admin_, bytes _data) payable',
+    'event AdminChanged(address previousAdmin, address newAdmin)',
+    'event Upgraded(address indexed implementation)',
+    'fallback()',
+    'function admin() returns (address admin_)',
+    'function changeAdmin(address newAdmin)',
+    'function implementation() returns (address implementation_)',
+    'function upgradeTo(address newImplementation)',
+    'function upgradeToAndCall(address newImplementation, bytes data) payable',
+    'receive() external payable',
+  ],
+  logicAbi: [
+    'event Approval(address indexed owner, address indexed spender, uint256 value)',
+    'event Transfer(address indexed from, address indexed to, uint256 value, bytes data)',
+    'event Transfer(address indexed from, address indexed to, uint256 value)',
+    'function DOMAIN_SEPARATOR() view returns (bytes32)',
+    'function allowance(address owner, address spender) view returns (uint256)',
+    'function approve(address spender, uint256 amount) returns (bool)',
+    'function balanceOf(address account) view returns (uint256)',
+    'function bridgeBurn(address account, uint256 amount)',
+    'function bridgeMint(address account, uint256 amount)',
+    'function decimals() view returns (uint8)',
+    'function decreaseAllowance(address spender, uint256 subtractedValue) returns (bool)',
+    'function deposit() payable',
+    'function depositTo(address account) payable',
+    'function increaseAllowance(address spender, uint256 addedValue) returns (bool)',
+    'function initialize(string _name, string _symbol, uint8 _decimals, address _l2Gateway, address _l1Address)',
+    'function l1Address() view returns (address)',
+    'function l2Gateway() view returns (address)',
+    'function name() view returns (string)',
+    'function nonces(address owner) view returns (uint256)',
+    'function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)',
+    'function symbol() view returns (string)',
+    'function totalSupply() view returns (uint256)',
+    'function transfer(address recipient, uint256 amount) returns (bool)',
+    'function transferAndCall(address _to, uint256 _value, bytes _data) returns (bool success)',
+    'function transferFrom(address sender, address recipient, uint256 amount) returns (bool)',
+    'function withdraw(uint256 amount)',
+    'function withdrawTo(address account, uint256 amount)',
+    'receive() external payable',
+  ],
+  logicAddress: '0x8b194bEae1d3e0788A1a35173978001ACDFba668',
+};
+
+export const deployedContracts = arbitrumDeployedContracts;

--- a/src/chains/arbitrum/index.ts
+++ b/src/chains/arbitrum/index.ts
@@ -1,7 +1,8 @@
 import { arbitrum as arbitrumMetadata } from '@wagmi/chains';
-import { sortedArrayByField } from '@/lib/utils';
+import { sortedArrayByField, sortedArrayByFields } from '@/lib/utils';
 import { Chain } from '@/types';
 import { accountTypes } from './accountTypes';
+import { deployedContracts } from './deployedContracts';
 import { signatureTypes } from './signatureTypes';
 import { opcodes } from './vm/opcodes';
 import { precompiles } from './vm/precompiles';
@@ -15,4 +16,5 @@ export const arbitrum: Chain = {
   accountTypes: sortedArrayByField(accountTypes, 'name'),
   opcodes: sortedArrayByField(opcodes, 'number'),
   mempools: [],
+  deployedContracts: sortedArrayByFields(deployedContracts, ['kind', 'name']),
 };

--- a/src/chains/mainnet/deployedContracts.ts
+++ b/src/chains/mainnet/deployedContracts.ts
@@ -1,0 +1,151 @@
+import { DeployedContract, DeployedContractKind } from '@/types';
+
+const contracts: DeployedContract[] = [
+  {
+    name: 'Wrapped Native Token',
+    description:
+      'It allows users to deposit Ether into the contract and receive ERC-20 WETH tokens in return.',
+    kind: DeployedContractKind.WrappedNativeAsset,
+    tokenName: 'Wrapped Ether',
+    tokenSymbol: 'WETH',
+    address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+    references: [
+      '[Alchemy Smart Contract Repository](https://www.alchemy.com/smart-contracts/weth9)',
+    ],
+    logicAbi: [
+      'function name() view returns (string)',
+      'function approve(address guy, uint256 wad) returns (bool)',
+      'function totalSupply() view returns (uint256)',
+      'function transferFrom(address src, address dst, uint256 wad) returns (bool)',
+      'function withdraw(uint256 wad)',
+      'function decimals() view returns (uint8)',
+      'function balanceOf(address) view returns (uint256)',
+      'function symbol() view returns (string)',
+      'function transfer(address dst, uint256 wad) returns (bool)',
+      'function deposit() payable',
+      'function allowance(address, address) view returns (uint256)',
+      'fallback()',
+      'event Approval(address indexed src, address indexed guy, uint256 wad)',
+      'event Transfer(address indexed src, address indexed dst, uint256 wad)',
+      'event Deposit(address indexed dst, uint256 wad)',
+      'event Withdrawal(address indexed src, uint256 wad)',
+    ],
+  },
+  {
+    name: 'Multicall3',
+    description: 'The Multicall3 contract enables batched read or write operations.',
+    kind: DeployedContractKind.Utility,
+    address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+    deploymentInstructions:
+      'https://github.com/mds1/multicall/blob/main/README.md#new-deployments.',
+    references: ['[Multicall3 website](https://www.multicall3.com/)'],
+    logicAbi: [
+      'struct Call { address target; bytes callData; }',
+      'struct Call3 { address target; bool allowFailure; bytes callData; }',
+      'struct Call3Value { address target; bool allowFailure; uint256 value; bytes callData; }',
+      'struct Result { bool success; bytes returnData; }',
+      'function aggregate(Call[] calldata calls) public payable returns (uint256 blockNumber, bytes[] memory returnData)',
+      'function aggregate3(Call3[] calldata calls) public payable returns (Result[] memory returnData)',
+      'function aggregate3Value(Call3Value[] calldata calls) public payable returns (Result[] memory returnData)',
+      'function blockAndAggregate(Call[] calldata calls) public payable returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData)',
+      'function getBasefee() view returns (uint256 basefee)',
+      'function getBlockHash(uint256 blockNumber) view returns (bytes32 blockHash)',
+      'function getBlockNumber() view returns (uint256 blockNumber)',
+      'function getChainId() view returns (uint256 chainid)',
+      'function getCurrentBlockCoinbase() view returns (address coinbase)',
+      'function getCurrentBlockDifficulty() view returns (uint256 difficulty)',
+      'function getCurrentBlockGasLimit() view returns (uint256 gaslimit)',
+      'function getCurrentBlockTimestamp() view returns (uint256 timestamp)',
+      'function getEthBalance(address addr) view returns (uint256 balance)',
+      'function getLastBlockHash() view returns (bytes32 blockHash)',
+      'function tryAggregate(bool requireSuccess, Call[] calldata calls) public payable returns (Result[] memory returnData)',
+      'function tryBlockAndAggregate(bool requireSuccess, Call[] calldata calls) public payable returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData)',
+    ],
+  },
+  {
+    name: "Nick Johnson's Create2 Deployer",
+    description:
+      'A contract that allows you to deploy contracts to a deterministic address with CREATE2.',
+    kind: DeployedContractKind.Utility,
+    address: '0x4e59b44847b379578588920cA78FbF26c0B4956C',
+    deploymentInstructions:
+      'https://github.com/Arachnid/deterministic-deployment-proxy/blob/master/README.md#deployment-transaction',
+    references: [
+      'https://github.com/Arachnid/deterministic-deployment-proxy/blob/master/README.md',
+    ],
+    logicAbi: [
+      // Since the contract is written in Yul, it has no Solidity ABI.
+      JSON.stringify({
+        payable: true,
+        stateMutability: 'payable',
+        type: 'fallback',
+        inputs: [
+          {
+            internalType: 'bytes32',
+            name: 'salt',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'creationCode',
+            type: 'bytes',
+          },
+        ],
+      }),
+    ],
+  },
+  {
+    name: "0age's Create2 Deployer",
+    description:
+      'A contract that allows you to deploy contracts to a deterministic address with CREATE2, and provides a safe deployment method that ensures the first 20 bytes of the salt are equal to the address of the caller.',
+    kind: DeployedContractKind.Utility,
+    address: '0x0000000000FFe8B47B3e2130213B802212439497',
+    deploymentInstructions:
+      'https://github.com/ProjectOpenSea/seaport/blob/main/docs/Deployment.md#setting-up-factory-on-a-new-chain.',
+    references: [
+      '[Etherscan: Keyless CREATE2 Factory](https://etherscan.io/address/0x0000000000FFe8B47B3e2130213B802212439497#code)',
+    ],
+    logicAbi: [
+      'function hasBeenDeployed(address deploymentAddress) view returns (bool)',
+      'function safeCreate2(bytes32 salt, bytes initializationCode) payable returns (address deploymentAddress)',
+      'function findCreate2Address(bytes32 salt, bytes initCode) view returns (address deploymentAddress)',
+      'function findCreate2AddressViaHash(bytes32 salt, bytes32 initCodeHash) view returns (address deploymentAddress)',
+    ],
+  },
+  {
+    name: "pcaversaccio's Create2 Deployer",
+    description:
+      'A contract that allows you to deploy contracts to a deterministic address with CREATE2, and is part of a Hardhat plugin to simplify deterministic deployments.',
+    kind: DeployedContractKind.Utility,
+    address: '0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2',
+    deploymentInstructions:
+      'See https://github.com/pcaversaccio/xdeployer/blob/main/README.md#local-deployment to deploy locally, or open an issue in that repo to request a new deployment.',
+    references: ['https://github.com/pcaversaccio/xdeployer/blob/main/README.md#local-deployment'],
+    logicAbi: [
+      'event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)',
+      'event Paused(address account)',
+      'event Unpaused(address account)',
+      'function computeAddress(bytes32 salt, bytes32 codeHash) view returns (address)',
+      'function computeAddressWithDeployer(bytes32 salt, bytes32 codeHash, address deployer) pure returns (address)',
+      'function deploy(uint256 value, bytes32 salt, bytes code)',
+      'function deployERC1820Implementer(uint256 value, bytes32 salt)',
+      'function killCreate2Deployer(address payoutAddress)',
+      'function owner() view returns (address)',
+      'function pause()',
+      'function paused() view returns (bool)',
+      'function renounceOwnership()',
+      'function transferOwnership(address newOwner)',
+      'function unpause()',
+      'receive() external payable',
+    ],
+  },
+];
+
+// Reshape into a map where the key is the name.
+export const deployedContracts: Record<string, DeployedContract> = contracts.reduce(
+  (acc, contract) => {
+    acc[contract.name] = contract;
+    return acc;
+  },
+  {} as Record<string, DeployedContract>
+);

--- a/src/chains/mainnet/index.ts
+++ b/src/chains/mainnet/index.ts
@@ -1,7 +1,8 @@
 import { mainnet as mainnetMetadata } from '@wagmi/chains';
-import { sortedArrayByField } from '@/lib/utils';
+import { sortedArrayByField, sortedArrayByFields } from '@/lib/utils';
 import { Chain } from '@/types';
 import { accountTypes } from './accountTypes';
+import { deployedContracts } from './deployedContracts';
 import { mempools } from './mempools';
 import { signatureTypes } from './signatureTypes';
 import { opcodes } from './vm/opcodes';
@@ -16,4 +17,5 @@ export const mainnet: Chain = {
   accountTypes: sortedArrayByField(accountTypes, 'name'),
   opcodes: sortedArrayByField(opcodes, 'number'),
   mempools: sortedArrayByField(mempools, 'name'),
+  deployedContracts: sortedArrayByFields(deployedContracts, ['kind', 'name']),
 };

--- a/src/chains/optimism/deployedContracts.ts
+++ b/src/chains/optimism/deployedContracts.ts
@@ -1,0 +1,31 @@
+import { deployedContracts as mainnetDeployedContracts } from '@/chains/mainnet/deployedContracts';
+
+const optimismDeployedContracts = { ...mainnetDeployedContracts };
+optimismDeployedContracts['Wrapped Native Token'] = {
+  ...optimismDeployedContracts['Wrapped Native Token'],
+  address: '0x4200000000000000000000000000000000000006',
+  references: [
+    ...optimismDeployedContracts['Wrapped Native Token'].references,
+    '[Optimism Docs: What is ETH? WETH?](https://help.optimism.io/hc/en-us/articles/4417948883611-What-is-ETH-WETH-How-do-they-interact-)',
+  ],
+  logicAbi: [
+    'event Approval(address indexed src, address indexed guy, uint256 wad)',
+    'event Deposit(address indexed dst, uint256 wad)',
+    'event Transfer(address indexed src, address indexed dst, uint256 wad)',
+    'event Withdrawal(address indexed src, uint256 wad)',
+    'fallback()',
+    'function allowance(address, address) view returns (uint256)',
+    'function approve(address guy, uint256 wad) returns (bool)',
+    'function balanceOf(address) view returns (uint256)',
+    'function decimals() view returns (uint8)',
+    'function deposit() payable',
+    'function name() view returns (string)',
+    'function symbol() view returns (string)',
+    'function totalSupply() view returns (uint256)',
+    'function transfer(address dst, uint256 wad) returns (bool)',
+    'function transferFrom(address src, address dst, uint256 wad) returns (bool)',
+    'function withdraw(uint256 wad)',
+  ],
+};
+
+export const deployedContracts = optimismDeployedContracts;

--- a/src/chains/optimism/index.ts
+++ b/src/chains/optimism/index.ts
@@ -1,7 +1,8 @@
 import { optimism as optimismMetadata } from '@wagmi/chains';
-import { sortedArrayByField } from '@/lib/utils';
+import { sortedArrayByField, sortedArrayByFields } from '@/lib/utils';
 import { Chain } from '@/types';
 import { accountTypes } from './accountTypes';
+import { deployedContracts } from './deployedContracts';
 import { signatureTypes } from './signatureTypes';
 import { opcodes } from './vm/opcodes';
 import { precompiles } from './vm/precompiles';
@@ -15,4 +16,5 @@ export const optimism: Chain = {
   accountTypes: sortedArrayByField(accountTypes, 'name'),
   opcodes: sortedArrayByField(opcodes, 'number'),
   mempools: [],
+  deployedContracts: sortedArrayByFields(deployedContracts, ['kind', 'name']),
 };

--- a/src/components/diff/DiffAccountTypes.tsx
+++ b/src/components/diff/DiffAccountTypes.tsx
@@ -11,12 +11,12 @@ type Props = {
 };
 
 const formatAccountType = (contents: AccountType | undefined) => {
-  if (!contents) return <p>Not present</p>;
+  if (!contents) return <div>Not present</div>;
   return (
     <>
-      <p>
+      <div>
         <Markdown content={contents.description} />
-      </p>
+      </div>
       <div className='mt-4 text-sm'>
         {Object.entries(contents.properties).map(([key, value]) => {
           // Return a two column table of the property name and description.

--- a/src/components/diff/DiffDeployedContracts.tsx
+++ b/src/components/diff/DiffDeployedContracts.tsx
@@ -1,4 +1,5 @@
 import { Address, getAddress } from 'viem';
+import { Abi } from '@/components/diff/utils/Abi';
 import { Collapsible } from '@/components/diff/utils/Collapsible';
 import { Markdown } from '@/components/diff/utils/Markdown';
 import { RenderDiff } from '@/components/diff/utils/RenderDiff';
@@ -14,71 +15,6 @@ type Props = {
   base: DeployedContract[];
   target: DeployedContract[];
   onlyShowDiff: boolean;
-};
-
-const Abi = ({ deployedContract }: { deployedContract: DeployedContract }) => {
-  const hasProxyAbi = 'proxyAbi' in deployedContract && deployedContract.proxyAbi.length > 0;
-  const hasLogicAbi = 'logicAbi' in deployedContract && deployedContract.logicAbi.length > 0;
-  const hasLogicAddress =
-    'logicAddress' in deployedContract && deployedContract.logicAddress.length > 0;
-
-  let proxyAbi = <></>;
-  let logicAbi = <></>;
-
-  if (!hasProxyAbi) {
-    proxyAbi = <p className='text-sm'>ABI not found.</p>;
-  } else if (hasProxyAbi) {
-    proxyAbi = (
-      <ul>
-        {deployedContract.proxyAbi.map((sig) => (
-          <li key={sig} className='my-2 text-xs'>
-            <code>{sig}</code>
-          </li>
-        ))}
-      </ul>
-    );
-  }
-
-  if (!hasLogicAbi) {
-    logicAbi = <p className='text-sm'>ABI not found.</p>;
-  } else if (hasLogicAbi) {
-    logicAbi = (
-      <ul>
-        {deployedContract.logicAbi.map((sig) => (
-          <li key={sig} className='my-2 text-xs'>
-            <code>{sig}</code>
-          </li>
-        ))}
-      </ul>
-    );
-  }
-
-  const proxyAbiContent = (
-    <>
-      <div className='font-semibold'>Proxy Contract ABI</div>
-      {proxyAbi}
-      <div className='mt-4 font-semibold'>Logic Contract ABI</div>
-      <div className='text-secondary text-sm'>
-        {hasLogicAddress && (
-          <div className='mt-2 flex flex-1 items-center'>
-            {/* For some reason the text is not horizontally aligned so we manually add some margin to fix it */}
-            <div className='mr-1' style={{ marginBottom: '0.2rem' }}>
-              Implementation at
-            </div>
-            <Copyable
-              content={formatAddress(deployedContract.logicAddress)}
-              textToCopy={deployedContract.logicAddress}
-            />
-          </div>
-        )}
-      </div>
-      {logicAbi}
-    </>
-  );
-
-  return (
-    <Collapsible kind='custom' contents={hasProxyAbi ? proxyAbiContent : logicAbi} title='ABI' />
-  );
 };
 
 const formatDeployedContract = (deployedContract: DeployedContract | undefined) => {
@@ -115,7 +51,7 @@ const formatDeployedContract = (deployedContract: DeployedContract | undefined) 
         </div>
       </div>
       <div className='mt-4'>
-        <Abi deployedContract={deployedContract} />
+        <Abi contract={deployedContract} />
         <Collapsible kind='references' contents={deployedContract.references} />
       </div>
     </>

--- a/src/components/diff/DiffDeployedContracts.tsx
+++ b/src/components/diff/DiffDeployedContracts.tsx
@@ -1,0 +1,213 @@
+import { Address, getAddress } from 'viem';
+import { Collapsible } from '@/components/diff/utils/Collapsible';
+import { Markdown } from '@/components/diff/utils/Markdown';
+import { RenderDiff } from '@/components/diff/utils/RenderDiff';
+import { Copyable } from '@/components/ui/Copyable';
+import {
+  DeployedContract,
+  DeployedContractKind,
+  ProxiedDeployedContract,
+  StandardDeployedContract,
+} from '@/types';
+
+type Props = {
+  base: DeployedContract[];
+  target: DeployedContract[];
+  onlyShowDiff: boolean;
+};
+
+const Abi = ({ deployedContract }: { deployedContract: DeployedContract }) => {
+  const hasProxyAbi = 'proxyAbi' in deployedContract && deployedContract.proxyAbi.length > 0;
+  const hasLogicAbi = 'logicAbi' in deployedContract && deployedContract.logicAbi.length > 0;
+  const hasLogicAddress =
+    'logicAddress' in deployedContract && deployedContract.logicAddress.length > 0;
+
+  let proxyAbi = <></>;
+  let logicAbi = <></>;
+
+  if (!hasProxyAbi) {
+    proxyAbi = <p className='text-sm'>ABI not found.</p>;
+  } else if (hasProxyAbi) {
+    proxyAbi = (
+      <ul>
+        {deployedContract.proxyAbi.map((sig) => (
+          <li key={sig} className='my-2 text-xs'>
+            <code>{sig}</code>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (!hasLogicAbi) {
+    logicAbi = <p className='text-sm'>ABI not found.</p>;
+  } else if (hasLogicAbi) {
+    logicAbi = (
+      <ul>
+        {deployedContract.logicAbi.map((sig) => (
+          <li key={sig} className='my-2 text-xs'>
+            <code>{sig}</code>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  const proxyAbiContent = (
+    <>
+      <div className='font-semibold'>Proxy Contract ABI</div>
+      {proxyAbi}
+      <div className='mt-4 font-semibold'>Logic Contract ABI</div>
+      <div className='text-secondary text-sm'>
+        {hasLogicAddress && (
+          <div className='mt-2 flex flex-1 items-center'>
+            {/* For some reason the text is not horizontally aligned so we manually add some margin to fix it */}
+            <div className='mr-1' style={{ marginBottom: '0.2rem' }}>
+              Implementation at
+            </div>
+            <Copyable
+              content={formatAddress(deployedContract.logicAddress)}
+              textToCopy={deployedContract.logicAddress}
+            />
+          </div>
+        )}
+      </div>
+      {logicAbi}
+    </>
+  );
+
+  return (
+    <Collapsible kind='custom' contents={hasProxyAbi ? proxyAbiContent : logicAbi} title='ABI' />
+  );
+};
+
+const formatDeployedContract = (deployedContract: DeployedContract | undefined) => {
+  if (!deployedContract) return <p>Not present</p>;
+
+  const title =
+    deployedContract.kind === DeployedContractKind.WrappedNativeAsset ? (
+      <Markdown
+        codeSize='0.9rem'
+        content={`${deployedContract.tokenName!} (${deployedContract.tokenSymbol!})`}
+      />
+    ) : (
+      <Markdown codeSize='0.9rem' content={deployedContract.name} />
+    );
+
+  const addr = getAddress(deployedContract.address);
+  const deployInstructions = deployedContract.deploymentInstructions || 'N/A';
+
+  return (
+    <>
+      <div>{title}</div>
+      <div className='text-secondary text-sm'>
+        <Markdown content={deployedContract.description} />
+      </div>
+      <div className='text-secondary mt-3 grid grid-cols-4 space-y-1 text-sm'>
+        <div className='col-span-2'>Address</div>
+        <div className='col-span-2'>
+          <Copyable content={formatAddress(addr)} textToCopy={getAddress(addr)} />
+        </div>
+
+        <div className='col-span-2'>Deploy Instructions</div>
+        <div className='col-span-2'>
+          <Markdown content={deployInstructions} />
+        </div>
+      </div>
+      <div className='mt-4'>
+        <Abi deployedContract={deployedContract} />
+        <Collapsible kind='references' contents={deployedContract.references} />
+      </div>
+    </>
+  );
+};
+
+const formatAddress = (addr: Address) => {
+  addr = getAddress(addr);
+  return <code className='text-sm'>{`${addr.slice(0, 6)}...${addr.slice(-4)}`}</code>;
+};
+
+type OmittedStandardDeployedContract = Omit<
+  StandardDeployedContract,
+  'description' | 'deploymentInstructions' | 'references'
+>;
+type OmittedProxiedDeployedContract = Omit<
+  ProxiedDeployedContract,
+  'description' | 'deploymentInstructions' | 'references'
+>;
+
+export const convertToComparableContract = (
+  contract: DeployedContract | undefined
+): OmittedStandardDeployedContract | OmittedProxiedDeployedContract | undefined => {
+  if (typeof contract === 'undefined') return undefined;
+
+  const baseReturnData: OmittedStandardDeployedContract = {
+    name: contract.name,
+    kind: contract.kind,
+    tokenName: contract.tokenName,
+    tokenSymbol: contract.tokenSymbol,
+    address: contract.address,
+    notes: contract.notes,
+    logicAbi: contract.logicAbi.sort(),
+  };
+
+  if ('proxyAbi' in contract) {
+    const proxiedReturnData: OmittedProxiedDeployedContract = {
+      ...baseReturnData,
+      proxyAbi: contract.proxyAbi.sort(),
+      logicAddress: contract.logicAddress,
+    };
+    return proxiedReturnData;
+  }
+
+  return baseReturnData;
+};
+
+export const DiffDeployedContracts = ({ base, target, onlyShowDiff }: Props) => {
+  const sortedNames = [...base.map((c) => c.name), ...target.map((c) => c.name)].sort((a, b) =>
+    a.localeCompare(b)
+  );
+  const deployedContractNames = [...new Set(sortedNames)];
+
+  const diffContent = (
+    <>
+      {deployedContractNames.map((name) => {
+        const baseDeployedContract = base.find((c) => c.name === name);
+        const targetDeployedContract = target.find((c) => c.name === name);
+
+        console.log('==========');
+        console.log(name);
+        console.log(
+          'convertToComparableContract(baseDeployedContract):',
+          convertToComparableContract(baseDeployedContract)
+        );
+        console.log(
+          'convertToComparableContract(targetDeployedContract):',
+          convertToComparableContract(targetDeployedContract)
+        );
+        const isEqual =
+          JSON.stringify(convertToComparableContract(baseDeployedContract)) ===
+          JSON.stringify(convertToComparableContract(targetDeployedContract));
+        console.log('isEqual:', isEqual);
+        const showDeployedContract = !isEqual || !onlyShowDiff;
+
+        return (
+          showDeployedContract && (
+            <div
+              key={name}
+              className='grid grid-cols-12 items-center border-b border-zinc-500/10 py-6 dark:border-zinc-500/20'
+            >
+              <div className='col-span-2'>
+                <Copyable content={name} textToCopy={name} />
+              </div>
+              <div className='col-span-5 pr-4'>{formatDeployedContract(baseDeployedContract)}</div>
+              <div className='col-span-5'>{formatDeployedContract(targetDeployedContract)}</div>
+            </div>
+          )
+        );
+      })}
+    </>
+  );
+
+  return <RenderDiff content={diffContent} />;
+};

--- a/src/components/diff/DiffDeployedContracts.tsx
+++ b/src/components/diff/DiffDeployedContracts.tsx
@@ -111,21 +111,22 @@ export const DiffDeployedContracts = ({ base, target, onlyShowDiff }: Props) => 
         const baseDeployedContract = base.find((c) => c.name === name);
         const targetDeployedContract = target.find((c) => c.name === name);
 
-        console.log('==========');
-        console.log(name);
-        console.log(
-          'convertToComparableContract(baseDeployedContract):',
-          convertToComparableContract(baseDeployedContract)
-        );
-        console.log(
-          'convertToComparableContract(targetDeployedContract):',
-          convertToComparableContract(targetDeployedContract)
-        );
         const isEqual =
           JSON.stringify(convertToComparableContract(baseDeployedContract)) ===
           JSON.stringify(convertToComparableContract(targetDeployedContract));
-        console.log('isEqual:', isEqual);
+
         const showDeployedContract = !isEqual || !onlyShowDiff;
+
+        let formattedName: string | JSX.Element = name;
+        if (name.includes('Create2 Deployer')) {
+          const [first, _] = name.split('Create2 Deployer');
+          formattedName = (
+            <>
+              <div>{first}</div>
+              <div>Create2 Deployer</div>
+            </>
+          );
+        }
 
         return (
           showDeployedContract && (
@@ -133,9 +134,7 @@ export const DiffDeployedContracts = ({ base, target, onlyShowDiff }: Props) => 
               key={name}
               className='grid grid-cols-12 items-center border-b border-zinc-500/10 py-6 dark:border-zinc-500/20'
             >
-              <div className='col-span-2'>
-                <Copyable content={name} textToCopy={name} />
-              </div>
+              <div className='col-span-2'>{formattedName}</div>
               <div className='col-span-5 pr-4'>{formatDeployedContract(baseDeployedContract)}</div>
               <div className='col-span-5'>{formatDeployedContract(targetDeployedContract)}</div>
             </div>

--- a/src/components/diff/DiffPrecompiles.tsx
+++ b/src/components/diff/DiffPrecompiles.tsx
@@ -13,13 +13,13 @@ type Props = {
 
 const Abi = ({ precompile }: { precompile: Precompile }) => {
   let abi = (
-    <p className='text-sm italic'>
+    <div className='text-sm italic'>
       This interface is not yet rendered, but the data exists in the EVM Diff repository.
-    </p>
+    </div>
   );
 
   if ('logicAbi' in precompile && !precompile.logicAbi.length) {
-    abi = <p className='text-sm'>ABI not found.</p>;
+    abi = <div className='text-sm'>ABI not found.</div>;
   } else if ('logicAbi' in precompile && precompile.logicAbi.length > 0) {
     abi = (
       <ul>
@@ -36,15 +36,15 @@ const Abi = ({ precompile }: { precompile: Precompile }) => {
 };
 
 const formatPrecompile = (precompile: Precompile | undefined) => {
-  if (!precompile) return <p>Not present</p>;
+  if (!precompile) return <div>Not present</div>;
   return (
     <>
-      <p>
+      <div>
         <Markdown codeSize='0.9rem' content={precompile.name} />
-      </p>
-      <p className='text-secondary text-sm'>
+      </div>
+      <div className='text-secondary text-sm'>
         <Markdown content={precompile.description} />
-      </p>
+      </div>
       <div className='mt-4'>
         <Abi precompile={precompile} />
         <Collapsible kind='references' contents={precompile.references} />

--- a/src/components/diff/DiffPredeploys.tsx
+++ b/src/components/diff/DiffPredeploys.tsx
@@ -1,4 +1,5 @@
 import { Address, getAddress } from 'viem';
+import { Abi } from '@/components/diff/utils/Abi';
 import { Collapsible } from '@/components/diff/utils/Collapsible';
 import { Markdown } from '@/components/diff/utils/Markdown';
 import { RenderDiff } from '@/components/diff/utils/RenderDiff';
@@ -9,70 +10,6 @@ type Props = {
   base: Predeploy[];
   target: Predeploy[];
   onlyShowDiff: boolean;
-};
-
-const Abi = ({ predeploy }: { predeploy: Predeploy }) => {
-  const hasProxyAbi = 'proxyAbi' in predeploy && predeploy.proxyAbi.length > 0;
-  const hasLogicAbi = 'logicAbi' in predeploy && predeploy.logicAbi.length > 0;
-  const hasLogicAddress = 'logicAddress' in predeploy && predeploy.logicAddress.length > 0;
-
-  let proxyAbi = <></>;
-  let logicAbi = <></>;
-
-  if (!hasProxyAbi) {
-    proxyAbi = <p className='text-sm'>ABI not found.</p>;
-  } else if (hasProxyAbi) {
-    proxyAbi = (
-      <ul>
-        {predeploy.proxyAbi.map((sig) => (
-          <li key={sig} className='my-2 text-xs'>
-            <code>{sig}</code>
-          </li>
-        ))}
-      </ul>
-    );
-  }
-
-  if (!hasLogicAbi) {
-    logicAbi = <p className='text-sm'>ABI not found.</p>;
-  } else if (hasLogicAbi) {
-    logicAbi = (
-      <ul>
-        {predeploy.logicAbi.map((sig) => (
-          <li key={sig} className='my-2 text-xs'>
-            <code>{sig}</code>
-          </li>
-        ))}
-      </ul>
-    );
-  }
-
-  const proxyAbiContent = (
-    <>
-      <div className='font-semibold'>Proxy Contract ABI</div>
-      {proxyAbi}
-      <div className='mt-4 font-semibold'>Logic Contract ABI</div>
-      <div className='text-secondary text-sm'>
-        {hasLogicAddress && (
-          <div className='mt-2 flex flex-1 items-center'>
-            {/* For some reason the text is not horizontally aligned so we manually add some margin to fix it */}
-            <div className='mr-1' style={{ marginBottom: '0.2rem' }}>
-              Implementation at
-            </div>
-            <Copyable
-              content={formatAddress(predeploy.logicAddress)}
-              textToCopy={predeploy.logicAddress}
-            />
-          </div>
-        )}
-      </div>
-      {logicAbi}
-    </>
-  );
-
-  return (
-    <Collapsible kind='custom' contents={hasProxyAbi ? proxyAbiContent : logicAbi} title='ABI' />
-  );
 };
 
 const formatPredeploy = (predeploy: Predeploy | undefined) => {
@@ -86,7 +23,7 @@ const formatPredeploy = (predeploy: Predeploy | undefined) => {
         <Markdown content={predeploy.description} />
       </div>
       <div className='mt-4'>
-        <Abi predeploy={predeploy} />
+        <Abi contract={predeploy} />
         <Collapsible kind='references' contents={predeploy.references} />
       </div>
     </>

--- a/src/components/diff/utils/Abi.tsx
+++ b/src/components/diff/utils/Abi.tsx
@@ -1,0 +1,84 @@
+import { Address, getAddress } from 'viem';
+import { Collapsible } from '@/components/diff/utils/Collapsible';
+import { Copyable } from '@/components/ui/Copyable';
+
+const formatAddress = (addr: Address) => {
+  addr = getAddress(addr);
+  return <code className='text-sm'>{`${addr.slice(0, 6)}...${addr.slice(-4)}`}</code>;
+};
+
+type StandardContractAbi = {
+  logicAbi: string[];
+};
+
+type ProxiedContractAbi = {
+  proxyAbi: string[];
+  logicAbi: string[];
+  logicAddress: Address;
+};
+
+type ContractAbi = StandardContractAbi | ProxiedContractAbi;
+
+export const Abi = ({ contract }: { contract: ContractAbi }) => {
+  const hasProxyAbi = 'proxyAbi' in contract && contract.proxyAbi.length > 0;
+  const hasLogicAbi = 'logicAbi' in contract && contract.logicAbi.length > 0;
+  const hasLogicAddress = 'logicAddress' in contract && contract.logicAddress.length > 0;
+
+  let proxyAbi = <></>;
+  let logicAbi = <></>;
+
+  if (!hasProxyAbi) {
+    proxyAbi = <p className='text-sm'>ABI not found.</p>;
+  } else if (hasProxyAbi) {
+    proxyAbi = (
+      <ul>
+        {contract.proxyAbi.map((sig) => (
+          <li key={sig} className='my-2 text-xs'>
+            <code>{sig}</code>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (!hasLogicAbi) {
+    logicAbi = <p className='text-sm'>ABI not found.</p>;
+  } else if (hasLogicAbi) {
+    logicAbi = (
+      <ul>
+        {contract.logicAbi.map((sig) => (
+          <li key={sig} className='my-2 text-xs'>
+            <code>{sig}</code>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  const proxyAbiContent = (
+    <>
+      <div className='font-semibold'>Proxy Contract ABI</div>
+      {proxyAbi}
+      <div className='mt-4 font-semibold'>Logic Contract ABI</div>
+      <div className='text-secondary text-sm'>
+        {hasLogicAddress && (
+          <div className='mt-2 flex flex-1 items-center'>
+            {/* For some reason the text is not horizontally aligned so we manually add some margin to fix it */}
+            <div className='mr-1' style={{ marginBottom: '0.2rem' }}>
+              Implementation at
+            </div>
+            <Copyable
+              content={formatAddress(contract.logicAddress)}
+              textToCopy={contract.logicAddress}
+            />
+          </div>
+        )}
+      </div>
+      {logicAbi}
+    </>
+  );
+
+  return (
+    <Collapsible kind='custom' contents={hasProxyAbi ? proxyAbiContent : logicAbi} title='ABI' />
+  );
+};

--- a/src/components/diff/utils/Abi.tsx
+++ b/src/components/diff/utils/Abi.tsx
@@ -28,7 +28,7 @@ export const Abi = ({ contract }: { contract: ContractAbi }) => {
   let logicAbi = <></>;
 
   if (!hasProxyAbi) {
-    proxyAbi = <p className='text-sm'>ABI not found.</p>;
+    proxyAbi = <div className='text-sm'>ABI not found.</div>;
   } else if (hasProxyAbi) {
     proxyAbi = (
       <ul>
@@ -42,7 +42,7 @@ export const Abi = ({ contract }: { contract: ContractAbi }) => {
   }
 
   if (!hasLogicAbi) {
-    logicAbi = <p className='text-sm'>ABI not found.</p>;
+    logicAbi = <div className='text-sm'>ABI not found.</div>;
   } else if (hasLogicAbi) {
     logicAbi = (
       <ul>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -26,6 +26,23 @@ export const sortedArrayByField = <T extends number | string | symbol, U, K exte
   });
 };
 
+// Given a `record` (i.e. an object), return an array of its values sorted by the given `fields`,
+// in the order specified.
+// Make sure the field is a number or string or the sort behavior based on `>` and `<` may be
+// undefined.
+export const sortedArrayByFields = <T extends number | string | symbol, U, K extends keyof U>(
+  record: Record<T, U>,
+  fields: K[]
+): U[] => {
+  return (Object.values(record) as U[]).sort((a, b) => {
+    for (const field of fields) {
+      if (a[field] > b[field]) return 1;
+      if (a[field] < b[field]) return -1;
+    }
+    return 0;
+  });
+};
+
 // Returns a hex string with a leading `0x` and padded to 2 characters.
 export const formatPrefixByte = (prefix: number) => {
   return pad(`0x${prefix.toString(16).toUpperCase()}`, { size: 1 });

--- a/src/pages/diff.tsx
+++ b/src/pages/diff.tsx
@@ -4,6 +4,7 @@ import { LinkIcon } from '@heroicons/react/20/solid';
 import { getChainById } from '@/chains';
 import { ChainDiffSelector } from '@/components/ChainDiffSelector';
 import { DiffAccountTypes } from '@/components/diff/DiffAccountTypes';
+import { DiffDeployedContracts } from '@/components/diff/DiffDeployedContracts';
 import { DiffMempools } from '@/components/diff/DiffMempools';
 import { DiffMetadata } from '@/components/diff/DiffMetadata';
 import { DiffOpcodes } from '@/components/diff/DiffOpcodes';
@@ -36,6 +37,7 @@ const SECTION_MAP: Record<string, Section> = {
   accountTypes: { title: 'Account Types', component: DiffAccountTypes },
   opcodes: { title: 'Opcodes', component: DiffOpcodes },
   mempools: { title: 'Mempools', component: DiffMempools },
+  deployedContracts: { title: 'Deployed Contracts', component: DiffDeployedContracts },
 };
 
 const Diff = () => {

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -1,5 +1,6 @@
 import { Chain as Metadata } from '@wagmi/chains';
 import { AccountType } from './accountType';
+import { DeployedContract } from './deployedContract';
 import { Mempool } from './mempool';
 import { Opcode } from './opcode';
 import { Precompile } from './precompile';
@@ -14,4 +15,5 @@ export type Chain = {
   accountTypes: AccountType[];
   opcodes: Partial<Opcode>[];
   mempools: Mempool[];
+  deployedContracts: DeployedContract[];
 };

--- a/src/types/deployedContract.ts
+++ b/src/types/deployedContract.ts
@@ -17,11 +17,11 @@ type DeployedContractBase = {
   notes?: string[];
 };
 
-type StandardDeployedContract = DeployedContractBase & {
+export type StandardDeployedContract = DeployedContractBase & {
   logicAbi: string[];
 };
 
-type ProxiedDeployedContract = DeployedContractBase & {
+export type ProxiedDeployedContract = DeployedContractBase & {
   proxyAbi: string[];
   logicAbi: string[];
   logicAddress: Address;

--- a/src/types/deployedContract.ts
+++ b/src/types/deployedContract.ts
@@ -1,0 +1,30 @@
+import { Address } from 'viem';
+
+export enum DeployedContractKind {
+  WrappedNativeAsset,
+  Utility,
+}
+
+type DeployedContractBase = {
+  name: string;
+  description: string;
+  kind: DeployedContractKind;
+  tokenName?: string;
+  tokenSymbol?: string;
+  address: Address;
+  deploymentInstructions?: string;
+  references: string[];
+  notes?: string[];
+};
+
+type StandardDeployedContract = DeployedContractBase & {
+  logicAbi: string[];
+};
+
+type ProxiedDeployedContract = DeployedContractBase & {
+  proxyAbi: string[];
+  logicAbi: string[];
+  logicAddress: Address;
+};
+
+export type DeployedContract = StandardDeployedContract | ProxiedDeployedContract;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,5 +5,9 @@ export type { Predeploy } from './predeploy';
 export type { AccountType } from './accountType';
 export type { SignatureType } from './signatureType';
 export type { Mempool } from './mempool';
-export type { DeployedContract } from './deployedContract';
+export type {
+  DeployedContract,
+  StandardDeployedContract,
+  ProxiedDeployedContract,
+} from './deployedContract';
 export { DeployedContractKind } from './deployedContract';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,3 +5,5 @@ export type { Predeploy } from './predeploy';
 export type { AccountType } from './accountType';
 export type { SignatureType } from './signatureType';
 export type { Mempool } from './mempool';
+export type { DeployedContract } from './deployedContract';
+export { DeployedContractKind } from './deployedContract';


### PR DESCRIPTION
Closes https://github.com/mds1/evm-diff/issues/36

Implemented two kinds of contracts:
- Wrapped native token. For all existing chains this is WETH.
- Utility contracts. For all existing chains this is a set of create2 deployers.

The existing types and data can be expanded later to add other utility contracts, canonical token contracts, or addresses of protocol deploys. But to avoid scope creep, this section is kept simple for now.
