### PR TITLE
fix: remove hardfork properties from diff algorithm

### DIFF
--- a/src/chains/mainnet/eips.ts
+++ b/src/chains/mainnet/eips.ts
@@ -465,9 +465,6 @@ export const eip4399: EIP = {
 
   status: EIPState.Final,
   activeHardforks: hardforksFromParis,
-  notes: [
-    "PREVRANDAO returns the random output of the L1 beacon chain's oracle from approximately 5 L1 blocks ago.",
-  ],
   references: ['https://eips.ethereum.org/EIPS/eip-4399'],
 };
 

--- a/src/components/diff/DiffEIPs.tsx
+++ b/src/components/diff/DiffEIPs.tsx
@@ -23,11 +23,13 @@ export const DiffEIPs = ({ base, target, onlyShowDiff }: Props): JSX.Element => 
       {eipNumbers.map((number) => {
         const baseEIP = base.find((eip) => eip.number === number);
         const targetEIP = target.find((eip) => eip.number === number);
-        if (!baseEIP && !targetEIP) {
+        if (!baseEIP || !targetEIP) {
           return <></>;
         }
 
-        const isEqual = JSON.stringify(baseEIP) === JSON.stringify(targetEIP);
+        const isEqual =
+          JSON.stringify(convertToComparableEIP(baseEIP)) ===
+          JSON.stringify(convertToComparableEIP(targetEIP));
         const showOpcode = !isEqual || !onlyShowDiff;
 
         return (
@@ -128,4 +130,21 @@ const formatEIPParameters = (params: EIPParameter[]): JSX.Element => {
     </>
   );
   return <Collapsible kind='custom' title='Parameters' contents={contents} />;
+};
+
+// Convert an `EIP` object to a simpler struct in order to compare it to other EIPs.
+// Note: casting an object from a type with properties X, Y and Z to a subset type with properties
+// X and Y using the `as` keyword will still retain the field Z unless you explicitly remove it.
+// That's why this function exists.
+export const convertToComparableEIP = (eip: EIP): Omit<EIP, 'activeHardforks'> => {
+  return {
+    number: eip.number,
+    title: eip.title,
+    category: eip.category,
+    status: eip.status,
+    deprecated: eip.deprecated,
+    parameters: eip.parameters,
+    notes: eip.notes,
+    references: eip.references,
+  };
 };

--- a/src/components/diff/DiffOpcodes.tsx
+++ b/src/components/diff/DiffOpcodes.tsx
@@ -285,7 +285,7 @@ export const DiffOpcodes = ({ base, target, onlyShowDiff }: Props): JSX.Element 
 // That's why this function exists.
 export const convertToComparableOpcode = (
   opcode: Opcode
-): Omit<Opcode, 'examples' | 'playgroundLink' | 'notes' | 'references'> => {
+): Omit<Opcode, 'examples' | 'playgroundLink' | 'notes' | 'references' | 'supportedHardforks'> => {
   return {
     number: opcode.number,
     name: opcode.name,
@@ -295,6 +295,5 @@ export const convertToComparableOpcode = (
     inputs: opcode.inputs,
     outputs: opcode.outputs,
     errorCases: opcode.errorCases,
-    supportedHardforks: opcode.supportedHardforks,
   };
 };

--- a/src/pages/diff.tsx
+++ b/src/pages/diff.tsx
@@ -40,9 +40,9 @@ const SECTION_MAP: Record<string, Section> = {
   opcodes: { title: 'Opcodes', component: DiffOpcodes },
   mempools: { title: 'Mempools', component: DiffMempools },
   deployedContracts: { title: 'Deployed Contracts', component: DiffDeployedContracts },
-  eips: { title: 'EIPs', component: DiffEIPs },
+  eips: { title: 'Execution EIPs', component: DiffEIPs },
   executionNodes: { title: 'Execution Nodes', component: DiffNodes },
-  consensusNodes: { title: 'Consensus Nodes', component: DiffNodes },
+  consensusNodes: { title: 'Consensus Nodes', component: DiffNodes, hide: true }, // Hidden to scope UI to execution data
 };
 
 const Diff = () => {


### PR DESCRIPTION
Resolves #55 

It applies to all the types that have hardfork properties so `Opcode` and `EIP` types.

