### PR TITLE
feat: arbitrum eips diffs

### DIFF
--- a/src/chains/arbitrum/eips.ts
+++ b/src/chains/arbitrum/eips.ts
@@ -1,0 +1,28 @@
+import { EIP, EIPCategory } from '@/types/eip';
+import { eip1559 as eip1559OnMainnet, eips as ethereumEIPs } from '../mainnet/eips';
+import { ArbitrumHardfork, getArbitrumHardforksFrom } from './hardforks';
+
+const hardforksFromArbOS11: string[] = getArbitrumHardforksFrom(ArbitrumHardfork.ArbOS11);
+const eip1559OnArbitrum: EIP = {
+  ...eip1559OnMainnet,
+  activeHardforks: hardforksFromArbOS11,
+  parameters: [],
+  notes: [
+    'EIP-1599 is not implemented on Arbitrum but Arbitrum implements an "exponential mechanism" which has been shown equivalent to Ethereum\'s EIP-1559 gas pricing mechanism.',
+  ],
+  references: [
+    ...eip1559OnMainnet.references,
+    'https://docs.arbitrum.io/inside-arbitrum-nitro#l2-gas-fees',
+  ],
+};
+
+export const eips: EIP[] = ethereumEIPs
+  .filter((eip) => {
+    // Exclude consensus-related EIPs.
+    return eip.category !== EIPCategory.Consensus;
+  })
+  .map((eip) => {
+    // EIPs modified by Optimism hard forks.
+    if (eip.number === 1559) return eip1559OnArbitrum;
+    return eip;
+  });

--- a/src/chains/arbitrum/eips.ts
+++ b/src/chains/arbitrum/eips.ts
@@ -22,7 +22,7 @@ const eip1559OnArbitrum: EIP = {
 
 const eip4399OnArbitrum: EIP = {
   ...eip1399OnMainnet,
-  notes: ['PREVRANDAO returns the constant `1` on Arbitrum.'],
+  notes: ['PREVRANDAO returns the constant 1 on Arbitrum.'],
   references: [...eip1399OnMainnet.references, 'https://developer.arbitrum.io/solidity-support'],
 };
 

--- a/src/chains/arbitrum/eips.ts
+++ b/src/chains/arbitrum/eips.ts
@@ -1,5 +1,9 @@
 import { EIP, EIPCategory } from '@/types/eip';
-import { eip1559 as eip1559OnMainnet, eips as ethereumEIPs } from '../mainnet/eips';
+import {
+  eip4399 as eip1399OnMainnet,
+  eip1559 as eip1559OnMainnet,
+  eips as ethereumEIPs,
+} from '../mainnet/eips';
 import { ArbitrumHardfork, getArbitrumHardforksFrom } from './hardforks';
 
 const hardforksFromArbOS11: string[] = getArbitrumHardforksFrom(ArbitrumHardfork.ArbOS11);
@@ -16,6 +20,12 @@ const eip1559OnArbitrum: EIP = {
   ],
 };
 
+const eip4399OnArbitrum: EIP = {
+  ...eip1399OnMainnet,
+  notes: ['PREVRANDAO returns the constant `1` on Arbitrum.'],
+  references: [...eip1399OnMainnet.references, 'https://developer.arbitrum.io/solidity-support'],
+};
+
 export const eips: EIP[] = ethereumEIPs
   .filter((eip) => {
     // Exclude consensus-related EIPs.
@@ -24,5 +34,6 @@ export const eips: EIP[] = ethereumEIPs
   .map((eip) => {
     // EIPs modified by Optimism hard forks.
     if (eip.number === 1559) return eip1559OnArbitrum;
+    if (eip.number === 4399) return eip4399OnArbitrum;
     return eip;
   });

--- a/src/chains/arbitrum/eips.ts
+++ b/src/chains/arbitrum/eips.ts
@@ -32,7 +32,7 @@ export const eips: EIP[] = ethereumEIPs
     return eip.category !== EIPCategory.Consensus;
   })
   .map((eip) => {
-    // EIPs modified by Optimism hard forks.
+    // EIPs modified by Arbitrum hard forks.
     if (eip.number === 1559) return eip1559OnArbitrum;
     if (eip.number === 4399) return eip4399OnArbitrum;
     return eip;

--- a/src/chains/arbitrum/eips.ts
+++ b/src/chains/arbitrum/eips.ts
@@ -2,6 +2,7 @@ import { EIP, EIPCategory } from '@/types/eip';
 import {
   eip4399 as eip1399OnMainnet,
   eip1559 as eip1559OnMainnet,
+  eip4895 as eip4895OnMainnet,
   eips as ethereumEIPs,
 } from '../mainnet/eips';
 import { ArbitrumHardfork, getArbitrumHardforksFrom } from './hardforks';
@@ -13,6 +14,9 @@ const eip1559OnArbitrum: EIP = {
   parameters: [],
   notes: [
     'EIP-1599 is not implemented on Arbitrum but Arbitrum implements an "exponential mechanism" which has been shown equivalent to Ethereum\'s EIP-1559 gas pricing mechanism.',
+    'EIP-1559 is partially implemented with the following exceptions:',
+    '- Target a gas per second ("speed limit") instead of block gas limit to account for the variable block time in Arbitrum.',
+    '- Priority fee is not collected by the network even when nonzero value is specified.',
   ],
   references: [
     ...eip1559OnMainnet.references,
@@ -26,6 +30,15 @@ const eip4399OnArbitrum: EIP = {
   references: [...eip1399OnMainnet.references, 'https://developer.arbitrum.io/solidity-support'],
 };
 
+const eip4895OnArbitrum: EIP = {
+  ...eip4895OnMainnet,
+  notes: ['Arbitrum currently do not generate block with withdrawalsRoot.'],
+  references: [
+    ...eip4895OnMainnet.references,
+    'https://github.com/mds1/evm-diff/pull/60#issuecomment-1926794404',
+  ],
+};
+
 export const eips: EIP[] = ethereumEIPs
   .filter((eip) => {
     // Exclude consensus-related EIPs.
@@ -35,5 +48,6 @@ export const eips: EIP[] = ethereumEIPs
     // EIPs modified by Arbitrum hard forks.
     if (eip.number === 1559) return eip1559OnArbitrum;
     if (eip.number === 4399) return eip4399OnArbitrum;
+    if (eip.number === 4895) return eip4895OnArbitrum;
     return eip;
   });

--- a/src/chains/arbitrum/hardforks.ts
+++ b/src/chains/arbitrum/hardforks.ts
@@ -11,6 +11,21 @@ export enum ArbitrumHardfork {
 
 export const CURRENT_ARBITRUM_HARDFORK = ArbitrumHardfork.ArbOS11;
 
+// Format Arbitrum hardforks according to the pattern 'ArbOS Version {number}'.
+const formattedArbitrumHardforks = (): string[] => {
+  return Object.values(ArbitrumHardfork)
+    .filter((v) => typeof v === 'string')
+    .map((v, _) => {
+      const regex = /ArbOS(.*)/;
+      const match = v.toString().match(regex);
+      if (match) {
+        const version = match[1];
+        return `ArbOS Version ${version}`;
+      }
+      return v.toString();
+    });
+};
+
 // Retrieve all the hard forks from the starting hard fork to the current mainnet hard fork.
 export const getArbitrumHardforksFrom = (startingHardfork: ArbitrumHardfork): string[] =>
   getArbitrumHardforksFromTo(startingHardfork, CURRENT_ARBITRUM_HARDFORK);
@@ -20,17 +35,11 @@ export const getArbitrumHardforksFromTo = (
   start: ArbitrumHardfork,
   end: ArbitrumHardfork
 ): string[] => {
+  const arbitrumHardforks = formattedArbitrumHardforks();
   if (start > end) {
     throw new Error(
-      `Error: the starting hard fork ${ArbitrumHardfork[start]} (index: ${start}) occurred after the ending hard fork ${ArbitrumHardfork[end]} (index: ${end}). Arguments are wrong or must have been reversed.`
+      `Error: the starting hard fork ${arbitrumHardforks[start]} (index: ${start}) occurred after the ending hard fork ${arbitrumHardforks[end]} (index: ${end}). Arguments are wrong or must have been reversed.`
     );
   }
-
-  // Create an array made of all the enum key indexes following by all the stringified keys.
-  // For example, if you had an enum with two keys A and B, you would get ['0', '1', 'A', 'B'].
-  // Then, we only keep the slice with the values (e.g. ['A', 'B']).
-  const array = Object.keys(ArbitrumHardfork);
-  const length = array.length / 2;
-  const keys = array.slice(length);
-  return keys.slice(start, end + 1);
+  return arbitrumHardforks.slice(start, end + 1);
 };

--- a/src/chains/arbitrum/hardforks.ts
+++ b/src/chains/arbitrum/hardforks.ts
@@ -1,0 +1,31 @@
+// List of Arbitrum upgrades or hard forks.
+// https://forum.arbitrum.foundation/t/arbitrum-arbos-upgrades/19695
+export enum ArbitrumHardfork {
+  ArbOS11,
+}
+
+export const CURRENT_ARBITRUM_HARDFORK = ArbitrumHardfork.ArbOS11;
+
+// Retrieve all the hard forks from the starting hard fork to the current mainnet hard fork.
+export const getArbitrumHardforksFrom = (startingHardfork: ArbitrumHardfork): string[] =>
+  getArbitrumHardforksFromTo(startingHardfork, CURRENT_ARBITRUM_HARDFORK);
+
+// Retrieve an array of hardforks from a starting hardfork to an ending hardfork (inclusive).
+export const getArbitrumHardforksFromTo = (
+  start: ArbitrumHardfork,
+  end: ArbitrumHardfork
+): string[] => {
+  if (start > end) {
+    throw new Error(
+      `Error: the starting hard fork ${ArbitrumHardfork[start]} (index: ${start}) occurred after the ending hard fork ${ArbitrumHardfork[end]} (index: ${end}). Arguments are wrong or must have been reversed.`
+    );
+  }
+
+  // Create an array made of all the enum key indexes following by all the stringified keys.
+  // For example, if you had an enum with two keys A and B, you would get ['0', '1', 'A', 'B'].
+  // Then, we only keep the slice with the values (e.g. ['A', 'B']).
+  const array = Object.keys(ArbitrumHardfork);
+  const length = array.length / 2;
+  const keys = array.slice(length);
+  return keys.slice(start, end + 1);
+};

--- a/src/chains/arbitrum/hardforks.ts
+++ b/src/chains/arbitrum/hardforks.ts
@@ -1,6 +1,11 @@
 // List of Arbitrum upgrades or hard forks.
 // https://forum.arbitrum.foundation/t/arbitrum-arbos-upgrades/19695
+// https://github.com/OffchainLabs/nitro/blob/17468a832e7430762911a9a202903aea79f9a047/cmd/chaininfo/arbitrum_chain_info.json
 export enum ArbitrumHardfork {
+  ArbOS1,
+  ArbOS2,
+  ArbOS6,
+  ArbOS10,
   ArbOS11,
 }
 

--- a/src/chains/arbitrum/index.ts
+++ b/src/chains/arbitrum/index.ts
@@ -3,6 +3,7 @@ import { sortedArrayByField, sortedArrayByFields } from '@/lib/utils';
 import { Chain } from '@/types';
 import { accountTypes } from './accountTypes';
 import { deployedContracts } from './deployedContracts';
+import { eips } from './eips';
 import { consensusNodes, executionNodes } from './nodes';
 import { signatureTypes } from './signatureTypes';
 import { opcodes } from './vm/opcodes';
@@ -18,7 +19,7 @@ export const arbitrum: Chain = {
   opcodes: sortedArrayByField(opcodes, 'number'),
   mempools: [],
   deployedContracts: sortedArrayByFields(deployedContracts, ['kind', 'name']),
-  eips: [],
+  eips,
   executionNodes,
   consensusNodes,
 };

--- a/src/chains/arbitrum/vm/opcodes/stack/push0.ts
+++ b/src/chains/arbitrum/vm/opcodes/stack/push0.ts
@@ -1,7 +1,8 @@
+import { ArbitrumHardfork, getArbitrumHardforksFrom } from '@/chains/arbitrum/hardforks';
 import { push0 as baseOpcode } from '@/chains/mainnet/vm/opcodes/stack/push';
 import { Opcode } from '@/types';
 
 export const push0: Opcode = {
   ...baseOpcode,
-  supportedHardforks: ['ArbOS 11'],
+  supportedHardforks: getArbitrumHardforksFrom(ArbitrumHardfork.ArbOS11),
 };

--- a/src/components/diff/utils/Markdown.tsx
+++ b/src/components/diff/utils/Markdown.tsx
@@ -43,10 +43,7 @@ export const Markdown: React.FC<{ content: string; codeSize?: string; className?
     // Add a fallback for any URLs that don't match the predefined patterns.
     // We take care to avoid matching URLs that are already included in markdown style.
     const fallbackPattern = /(?<!\]\()https?:\/\/[^\s]+/g;
-    return transformedContent.replace(
-      fallbackPattern,
-      (_match, fullUrl) => `[${fullUrl}](${fullUrl})`
-    );
+    return transformedContent.replace(fallbackPattern, (match, _) => `[${match}](${match})`);
   };
 
   const transformedContent = transformURLs(content);

--- a/src/components/diff/utils/format.tsx
+++ b/src/components/diff/utils/format.tsx
@@ -1,4 +1,5 @@
 import { MainnetHardfork } from '@/chains/mainnet/hardforks';
+import { CURRENT_OPTIMISM_HARDFORK, OptimismHardfork } from '@/chains/optimism/hardforks';
 import { CURRENT_MAINNET_HARDFORK } from '@/lib/constants';
 import { classNames, toUppercase } from '@/lib/utils';
 
@@ -7,26 +8,29 @@ export const formatHardfork = (array: string[]): JSX.Element => {
     return <p>No information provided on supported hard forks.</p>;
   }
 
-  const [first, ...rest] = array;
-  const last = rest.pop();
-  const length = array.length;
+  const first = array[0];
+  const last = array[array.length - 1];
   const currentMainnetHardforkName = MainnetHardfork[CURRENT_MAINNET_HARDFORK];
-  if (length == 1) {
+  const currentOptimismHardforkName = OptimismHardfork[CURRENT_OPTIMISM_HARDFORK];
+  if (array.length == 1) {
+    const supportedText =
+      first === currentMainnetHardforkName || first === currentOptimismHardforkName
+        ? `Supported since ${first} hard fork.`
+        : `Supported only in ${first} hard fork.`;
     return (
       <p className='text-sm'>
-        Supported only in <b>{first}</b> hard fork.
-      </p>
-    );
-  } else if (length == CURRENT_MAINNET_HARDFORK + 1 || last === currentMainnetHardforkName) {
-    return (
-      <p className='text-sm'>
-        Supported since <b>{first}</b> hard fork.
+        <b>{supportedText}</b>
       </p>
     );
   }
+
+  const supportedText =
+    last === currentMainnetHardforkName || last === currentOptimismHardforkName
+      ? `Supported since ${first} hard fork.`
+      : `Supported between ${first} and ${last} hard forks.`;
   return (
     <p className='text-sm'>
-      Supported between <b>{first}</b> and <b>{last}</b> hard forks.
+      <b>{supportedText}</b>
     </p>
   );
 };

--- a/src/components/diff/utils/format.tsx
+++ b/src/components/diff/utils/format.tsx
@@ -1,3 +1,4 @@
+import { ArbitrumHardfork, CURRENT_ARBITRUM_HARDFORK } from '@/chains/arbitrum/hardforks';
 import { MainnetHardfork } from '@/chains/mainnet/hardforks';
 import { CURRENT_OPTIMISM_HARDFORK, OptimismHardfork } from '@/chains/optimism/hardforks';
 import { CURRENT_MAINNET_HARDFORK } from '@/lib/constants';
@@ -12,9 +13,12 @@ export const formatHardfork = (array: string[]): JSX.Element => {
   const last = array[array.length - 1];
   const currentMainnetHardforkName = MainnetHardfork[CURRENT_MAINNET_HARDFORK];
   const currentOptimismHardforkName = OptimismHardfork[CURRENT_OPTIMISM_HARDFORK];
+  const currentArbitrumHardforkName = ArbitrumHardfork[CURRENT_ARBITRUM_HARDFORK];
   if (array.length == 1) {
     const supportedText =
-      first === currentMainnetHardforkName || first === currentOptimismHardforkName
+      first === currentMainnetHardforkName ||
+      first === currentOptimismHardforkName ||
+      first === currentArbitrumHardforkName
         ? `Supported since ${first} hard fork.`
         : `Supported only in ${first} hard fork.`;
     return (
@@ -25,7 +29,9 @@ export const formatHardfork = (array: string[]): JSX.Element => {
   }
 
   const supportedText =
-    last === currentMainnetHardforkName || last === currentOptimismHardforkName
+    last === currentMainnetHardforkName ||
+    last === currentOptimismHardforkName ||
+    last === currentArbitrumHardforkName
       ? `Supported since ${first} hard fork.`
       : `Supported between ${first} and ${last} hard forks.`;
   return (


### PR DESCRIPTION
Related to #37.
Requires #59 to be merged (and to rebase this PR).

Add Arbitrum EIPs diffs. Just like Optimism diffs (#53), it adds diffs for EIP-1599 and EIP-4399 (`PREVRANDAO`).
@mds1 Not sure about EIP-4895 (withdrawals lists)?

Also fix a url formatting issue.