### PR TITLE
add routescan explorers

### DIFF
--- a/script/data/chain/1.json
+++ b/script/data/chain/1.json
@@ -10,6 +10,7 @@
 		"ens": { "registry": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e" },
 		"explorers": [
 			{ "name": "etherscan", "url": "https://etherscan.io", "standard": "EIP3091" },
+			{ "name": "routescan", "url": "https://ethereum.routescan.io", "standard": "EIP3091" },
 			{
 				"name": "blockscout",
 				"url": "https://eth.blockscout.com",

--- a/script/data/chain/10.json
+++ b/script/data/chain/10.json
@@ -8,6 +8,7 @@
 		"nativeCurrency": { "name": "Ether", "symbol": "ETH", "decimals": 18 },
 		"chain": "ETH",
 		"explorers": [
+			{ "name": "routescan", "url": "https://mainnet.superscan.network", "standard": "EIP3091" },
 			{ "name": "etherscan", "url": "https://optimistic.etherscan.io", "standard": "EIP3091" },
 			{
 				"name": "blockscout",

--- a/script/data/chain/34443.json
+++ b/script/data/chain/34443.json
@@ -8,6 +8,7 @@
 		"nativeCurrency": { "name": "Ether", "symbol": "ETH", "decimals": 18 },
 		"chain": "ETH",
 		"explorers": [
+			{ "name": "routescan", "url": "https://modescan.io", "standard": "none" },
 			{ "name": "modescout", "url": "https://explorer.mode.network", "standard": "none" }
 		],
 		"faucets": [],

--- a/script/data/chain/42161.json
+++ b/script/data/chain/42161.json
@@ -8,6 +8,7 @@
 		"nativeCurrency": { "name": "Ether", "symbol": "ETH", "decimals": 18 },
 		"chain": "ETH",
 		"explorers": [
+			{ "name": "routescan", "url": "https://arbitrum.routescan.io", "standard": "EIP3091" },
 			{ "name": "Arbiscan", "url": "https://arbiscan.io", "standard": "EIP3091" },
 			{ "name": "Arbitrum Explorer", "url": "https://explorer.arbitrum.io", "standard": "EIP3091" },
 			{

--- a/script/data/chain/43114.json
+++ b/script/data/chain/43114.json
@@ -7,7 +7,11 @@
 		"infoURL": "https://www.avax.network/",
 		"nativeCurrency": { "name": "Avalanche", "symbol": "AVAX", "decimals": 18 },
 		"chain": "AVAX",
-		"explorers": [{ "name": "snowtrace", "url": "https://snowtrace.io", "standard": "EIP3091" }],
+		"explorers": [
+			{ "name": "routescan", "url": "https://snowtrace.io", "standard": "EIP3091" },
+			{ "name": "avascan", "url": "https://avascan.info", "standard": "EIP3091" },
+			{ "name": "etherscan", "url": "https://snowscan.xyz", "standard": "EIP3091" }
+		],
 		"faucets": [],
 		"features": [{ "name": "EIP1559" }],
 		"icon": "avax",

--- a/script/data/chain/8453.json
+++ b/script/data/chain/8453.json
@@ -8,6 +8,7 @@
 		"nativeCurrency": { "name": "Ether", "symbol": "ETH", "decimals": 18 },
 		"chain": "ETH",
 		"explorers": [
+			{ "name": "routescan", "url": "https://base.superscan.network", "standard": "none" },
 			{ "name": "basescan", "url": "https://basescan.org", "standard": "none" },
 			{
 				"name": "basescout",

--- a/script/data/feature/metadata.json
+++ b/script/data/feature/metadata.json
@@ -9,6 +9,7 @@
 		"chain": "ETH",
 		"ens": { "registry": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e" },
 		"explorers": [
+			{ "name": "routescan", "url": "https://ethereum.routescan.io", "standard": "EIP3091" },
 			{ "name": "etherscan", "url": "https://etherscan.io", "standard": "EIP3091" },
 			{
 				"name": "blockscout",
@@ -56,6 +57,7 @@
 		"nativeCurrency": { "name": "Ether", "symbol": "ETH", "decimals": 18 },
 		"chain": "ETH",
 		"explorers": [
+			{ "name": "routescan", "url": "https://mainnet.superscan.network", "standard": "EIP3091" },
 			{ "name": "etherscan", "url": "https://optimistic.etherscan.io", "standard": "EIP3091" },
 			{
 				"name": "blockscout",
@@ -125,6 +127,7 @@
 		"nativeCurrency": { "name": "Ether", "symbol": "ETH", "decimals": 18 },
 		"chain": "ETH",
 		"explorers": [
+			{ "name": "routescan", "url": "https://base.superscan.network", "standard": "none" },
 			{ "name": "basescan", "url": "https://basescan.org", "standard": "none" },
 			{
 				"name": "basescout",
@@ -160,6 +163,7 @@
 		"nativeCurrency": { "name": "Ether", "symbol": "ETH", "decimals": 18 },
 		"chain": "ETH",
 		"explorers": [
+			{ "name": "routescan", "url": "https://modescan.io", "standard": "none" },
 			{ "name": "modescout", "url": "https://explorer.mode.network", "standard": "none" }
 		],
 		"faucets": [],
@@ -175,6 +179,7 @@
 		"nativeCurrency": { "name": "Ether", "symbol": "ETH", "decimals": 18 },
 		"chain": "ETH",
 		"explorers": [
+			{ "name": "routescan", "url": "https://arbitrum.routescan.io", "standard": "EIP3091" },
 			{ "name": "Arbiscan", "url": "https://arbiscan.io", "standard": "EIP3091" },
 			{ "name": "Arbitrum Explorer", "url": "https://explorer.arbitrum.io", "standard": "EIP3091" },
 			{
@@ -206,7 +211,10 @@
 		"infoURL": "https://www.avax.network/",
 		"nativeCurrency": { "name": "Avalanche", "symbol": "AVAX", "decimals": 18 },
 		"chain": "AVAX",
-		"explorers": [{ "name": "snowtrace", "url": "https://snowtrace.io", "standard": "EIP3091" }],
+		"explorers": [
+			{ "name": "routescan", "url": "https://snowtrace.io", "standard": "EIP3091" },
+			{ "name": "avascan", "url": "https://avascan.info", "standard": "EIP3091" }
+		],
 		"faucets": [],
 		"features": [{ "name": "EIP1559" }],
 		"icon": "avax",

--- a/src/lib/chains.json
+++ b/src/lib/chains.json
@@ -1,7 +1,7 @@
 [
-	{ "chainId": 1, "name": "Ethereum Mainnet" },
 	{ "chainId": 10, "name": "OP Mainnet" },
 	{ "chainId": 137, "name": "Polygon Mainnet" },
+	{ "chainId": 1, "name": "Ethereum Mainnet" },
 	{ "chainId": 34443, "name": "Mode" },
 	{ "chainId": 42161, "name": "Arbitrum One" },
 	{ "chainId": 43114, "name": "Avalanche C-Chain" },


### PR DESCRIPTION
This PR is promoted by Routescan with the aim of improving the quality of the data as much as possible in an open-source manner.

The PR just adds the links to Routescan's explorer in the json chains data.
