### PR TITLE
feat: link to opcode rows

### DIFF
--- a/src/components/ui/Copyable.tsx
+++ b/src/components/ui/Copyable.tsx
@@ -41,7 +41,7 @@ export const Copyable = ({
 	};
 
 	return (
-		<div className={classNames('group group relative flex w-max items-center', className)}>
+		<div className={classNames('group relative flex w-max items-center', className)}>
 			<div className="relative flex w-full items-center">
 				{content}
 				<Icon


### PR DESCRIPTION
fCloses https://github.com/mds1/evm-diff/issues/80

It scrolls into the center of the window since I could not get it at aligned at the top—when I tried having scroll to the top it would be cut off (i.e. scrolled too far down). I suspect this is because of how the table scrolling is implemented

I also only implemented this for opcode support because the rest of the feature tables are much shorter so I don't think there's as much value here

cc @zerosnacks let me know how it works!