### PR TITLE
fix: add retry logic to handle 429s

### DIFF
--- a/script/checks/utils.ts
+++ b/script/checks/utils.ts
@@ -1,0 +1,36 @@
+import { sleep } from 'bun';
+import type { PublicClient } from 'viem';
+
+async function retryOnRateLimit<T>(
+	fn: () => Promise<T>,
+	maxRetries = 5,
+	initialDelay = 1000,
+): Promise<T> {
+	let retries = 0;
+	while (retries < maxRetries) {
+		try {
+			return await fn();
+		} catch (error) {
+			if (error instanceof Error && error.message.includes('429') && retries < maxRetries) {
+				const delay = initialDelay * 2 ** retries;
+				await sleep(delay);
+				retries++;
+			} else {
+				throw error;
+			}
+		}
+	}
+	throw new Error('Max retries reached');
+}
+
+export function createRetryClient(client: PublicClient): PublicClient {
+	return new Proxy(client, {
+		get(target, prop, receiver) {
+			const originalMethod = Reflect.get(target, prop, receiver);
+			if (typeof originalMethod === 'function') {
+				return (...args: unknown[]) => retryOnRateLimit(() => originalMethod.apply(target, args));
+			}
+			return originalMethod;
+		},
+	});
+}

--- a/script/index.ts
+++ b/script/index.ts
@@ -7,6 +7,7 @@ import {
 } from './checks/evm-stack-addresses';
 import { checkOpcodes } from './checks/opcodes';
 import { checkPrecompiles } from './checks/precompiles';
+import { createRetryClient } from './checks/utils';
 import type { Metadata } from './types';
 import { join } from 'node:path';
 
@@ -77,7 +78,7 @@ function initClient(rpcUrls: string[]) {
 	// Websocket seems to hang and script doesn't exit, so we only use HTTP.
 	const https = rpcUrls.filter((url) => url.startsWith('https')).map((url) => http(url));
 	const transport = fallback([...https]);
-	return createPublicClient({ transport });
+	return createRetryClient(createPublicClient({ transport }));
 }
 
 async function getMetadata(chainId: number): Promise<Metadata> {


### PR DESCRIPTION
CI runs to verify chain data is up to date have been failing due to 429s, such as this one: https://github.com/mds1/evm-diff/actions/runs/10858607707/job/30136810666

This PR wraps the viem client in a Proxy so all function calls are intercepted and automatically retried with exponential backoff