### PR TITLE
Use local data in development mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ yarn-error.log*
 # local env files
 .env*.local
 
+# local dev data
+/public/data
+
 # vercel
 .vercel
 

--- a/script/prepare-chain-data.sh
+++ b/script/prepare-chain-data.sh
@@ -44,4 +44,9 @@ cat > "$OUTPUT_FILE" <<EOL
 EOL
 
 bun fmt
-echo "✅ Successfully updated chains.json file"
+echo "✅ Successfully updated features.json file"
+
+# Copy data to public/ so Next.js can serve it locally in dev mode.
+rm -rf ./public/data
+cp -r ./script/data ./public/data
+echo "✅ Copied data to public/data for local dev"

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -11,7 +11,10 @@ export const TWITTER_URL = 'https://twitter.com/msolomon44';
 
 // -------- Other Data --------
 const BRANCH_NAME = process.env.NEXT_PUBLIC_BRANCH_NAME;
-export const BASE_DATA_URL = `https://raw.githubusercontent.com/mds1/evm-diff/${BRANCH_NAME}/script/data`;
+export const BASE_DATA_URL =
+	process.env.NODE_ENV === 'development'
+		? '/data'
+		: `https://raw.githubusercontent.com/mds1/evm-diff/${BRANCH_NAME}/script/data`;
 
 // This defines the source of truth for the data that is shown/hidden on the website.
 export interface Feature {


### PR DESCRIPTION
When developing a new feature, it's annoying to have to push something to github to have the data available. Plus, since I'm working on a fork, I also have to temporarily change the user of the base repository.

This PR changes things so that `bun dev` uses local data instead.